### PR TITLE
Allow user object name starts with '_'

### DIFF
--- a/src/H5VL_log_att.cpp
+++ b/src/H5VL_log_att.cpp
@@ -347,11 +347,20 @@ herr_t H5VL_log_attr_specific (void *obj,
             args->args.iterate.op_data = ctx;
         }
 
-        if (args->op_type == H5VL_ATTR_EXISTS) {
-            /* Rename user objects to avoid conflict with internal object */
-            original_name_arg      = args->args.exists.name;
-            iname_arg              = H5VL_logi_name_remap (original_name_arg);
-            args->args.exists.name = iname_arg;
+        switch (args->op_type) {
+            case H5VL_ATTR_EXISTS:;
+                /* Rename user objects to avoid conflict with internal object */
+                original_name_arg      = args->args.exists.name;
+                iname_arg              = H5VL_logi_name_remap (original_name_arg);
+                args->args.exists.name = iname_arg;
+                break;
+            case H5VL_ATTR_DELETE:;
+                /* Rename user objects to avoid conflict with internal object */
+                original_name_arg   = args->args.del.name;
+                iname_arg           = H5VL_logi_name_remap (original_name_arg);
+                args->args.del.name = iname_arg;
+                break;
+            default:;
         }
 
         H5VL_LOGI_PROFILING_TIMER_START;
@@ -382,7 +391,20 @@ err_out:;
     }
     if (iname_arg && iname_arg != original_name_arg) { free (iname_arg); }
     // Restore name in args
-    if (original_name_arg) { args->args.exists.name = original_name_arg; }
+    if (original_name_arg) {
+        switch (args->op_type) {
+            case H5VL_ATTR_EXISTS:;
+                args->args.exists.name = original_name_arg;
+                break;
+            case H5VL_ATTR_DELETE:;
+                args->args.del.name = original_name_arg;
+                break;
+            default:;
+#ifdef LOGVOL_DEBUG
+                RET_ERR ("Shouldn't reach here")
+#endif
+        }
+    }
     return err;
 } /* end H5VL_log_attr_specific() */
 

--- a/src/H5VL_log_att.cpp
+++ b/src/H5VL_log_att.cpp
@@ -14,6 +14,7 @@
 #include "H5VL_log_obj.hpp"
 #include "H5VL_log_req.hpp"
 #include "H5VL_logi.hpp"
+#include "H5VL_logi_util.hpp"
 
 /********************* */
 /* Function prototypes */
@@ -52,13 +53,14 @@ void *H5VL_log_attr_create (void *obj,
     H5VL_log_obj_t *op = (H5VL_log_obj_t *)obj;
     H5VL_log_obj_t *ap = NULL;
     H5VL_log_req_t *rp;
+    char *iname = NULL;  // Internal name of object
     void **ureqp, *ureq;
 
     try {
         H5VL_LOGI_PROFILING_TIMER_START;
 
-        /* Check arguments */
-        H5VL_LOGI_CHECK_NAME (name);
+        /* Rename user objects to avoid conflict with internal object */
+        iname = H5VL_logi_name_remap (name);
 
         ap = new H5VL_log_obj_t (op, H5I_ATTR);
 
@@ -70,7 +72,7 @@ void *H5VL_log_attr_create (void *obj,
         }
 
         H5VL_LOGI_PROFILING_TIMER_START;
-        ap->uo = H5VLattr_create (op->uo, loc_params, op->uvlid, name, type_id, space_id, acpl_id,
+        ap->uo = H5VLattr_create (op->uo, loc_params, op->uvlid, iname, type_id, space_id, acpl_id,
                                   aapl_id, dxpl_id, ureqp);
         H5VL_LOGI_PROFILING_TIMER_STOP (ap->fp, TIMER_H5VLATT_CREATE);
         CHECK_PTR (ap->uo);
@@ -84,10 +86,12 @@ void *H5VL_log_attr_create (void *obj,
     }
     H5VL_LOGI_EXP_CATCH
 
+    if (iname && iname != name) { free (iname); }
     return (void *)ap;
 
 err_out:;
     if (ap) { delete ap; }
+    if (iname && iname != name) { free (iname); }
 
     return NULL;
 } /* end H5VL_log_attr_create() */
@@ -111,13 +115,14 @@ void *H5VL_log_attr_open (void *obj,
     H5VL_log_obj_t *op = (H5VL_log_obj_t *)obj;
     H5VL_log_obj_t *ap = NULL;
     H5VL_log_req_t *rp;
+    char *iname = NULL;  // Internal name of object
     void **ureqp, *ureq;
 
     try {
         H5VL_LOGI_PROFILING_TIMER_START;
 
-        /* Check arguments */
-        H5VL_LOGI_CHECK_NAME (name);
+        /* Rename user objects to avoid conflict with internal object */
+        iname = H5VL_logi_name_remap (name);
 
         ap = new H5VL_log_obj_t (op, H5I_ATTR);
 
@@ -129,7 +134,7 @@ void *H5VL_log_attr_open (void *obj,
         }
 
         H5VL_LOGI_PROFILING_TIMER_START;
-        ap->uo = H5VLattr_open (op->uo, loc_params, op->uvlid, name, aapl_id, dxpl_id, ureqp);
+        ap->uo = H5VLattr_open (op->uo, loc_params, op->uvlid, iname, aapl_id, dxpl_id, ureqp);
         H5VL_LOGI_PROFILING_TIMER_STOP (ap->fp, TIMER_H5VLATT_OPEN);
         CHECK_PTR (ap->uo);
 
@@ -142,10 +147,12 @@ void *H5VL_log_attr_open (void *obj,
     }
     H5VL_LOGI_EXP_CATCH
 
+    if (iname && iname != name) { free (iname); }
     return (void *)ap;
 
 err_out:;
     if (ap) { delete ap; }
+    if (iname && iname != name) { free (iname); }
 
     return NULL;
 } /* end H5VL_log_attr_open() */

--- a/src/H5VL_log_atti.cpp
+++ b/src/H5VL_log_atti.cpp
@@ -20,9 +20,11 @@ herr_t H5VL_log_atti_iterate_op (hid_t location_id,
     // Skip internal objects
     if (attr_name) {
         if (attr_name[0] == '_') {
-            if (attr_name[1] == '_') attr_name++;
-        } else {
-            return 0;
+            if (attr_name[1] == '_')
+                attr_name++;
+            else {
+                return 0;
+            }
         }
         return ctx->op (location_id, attr_name, ainfo, ctx->op_data);
     }

--- a/src/H5VL_log_atti.cpp
+++ b/src/H5VL_log_atti.cpp
@@ -18,7 +18,12 @@ herr_t H5VL_log_atti_iterate_op (hid_t location_id,
     H5VL_log_atti_iterate_op_data *ctx = (H5VL_log_atti_iterate_op_data *)op_data;
 
     // Skip internal objects
-    if (attr_name && (attr_name[0] != '_' || attr_name[1] != '_')) {
+    if (attr_name) {
+        if (attr_name[0] == '_') {
+            if (attr_name[1] == '_') attr_name++;
+        } else {
+            return 0;
+        }
         return ctx->op (location_id, attr_name, ainfo, ctx->op_data);
     }
 

--- a/src/H5VL_log_dataseti.hpp
+++ b/src/H5VL_log_dataseti.hpp
@@ -13,9 +13,9 @@
 #include "H5VL_log_wrap.hpp"
 #include "H5VL_logi_idx.hpp"
 
-#define H5VL_LOG_DATASETI_ATTR_DIMS  "__dims"
-#define H5VL_LOG_DATASETI_ATTR_MDIMS "__mdims"
-#define H5VL_LOG_DATASETI_ATTR_ID    "__ID"
+#define H5VL_LOG_DATASETI_ATTR_DIMS  "_dims"
+#define H5VL_LOG_DATASETI_ATTR_MDIMS "_mdims"
+#define H5VL_LOG_DATASETI_ATTR_ID    "_ID"
 
 typedef struct H5VL_log_copy_ctx {
     char *src;    // Copy from

--- a/src/H5VL_log_datatype.cpp
+++ b/src/H5VL_log_datatype.cpp
@@ -13,6 +13,7 @@
 #include "H5VL_log_obj.hpp"
 #include "H5VL_log_req.hpp"
 #include "H5VL_logi.hpp"
+#include "H5VL_logi_util.hpp"
 
 /* Datatype callbacks */
 const H5VL_datatype_class_t H5VL_log_datatype_g {
@@ -47,10 +48,11 @@ void *H5VL_log_datatype_commit (void *obj,
     H5VL_log_obj_t *op = (H5VL_log_obj_t *)obj;
     H5VL_log_req_t *rp;
     void **ureqp, *ureq;
+    char *iname = NULL;  // Internal name of object
 
     try {
-        /* Check arguments */
-        H5VL_LOGI_CHECK_NAME (name);
+        /* Rename user objects to avoid conflict with internal object */
+        iname = H5VL_logi_name_remap (name);
 
         tp = new H5VL_log_obj_t (op, H5I_DATATYPE);
 
@@ -61,7 +63,7 @@ void *H5VL_log_datatype_commit (void *obj,
             ureqp = NULL;
         }
 
-        tp->uo = H5VLdatatype_commit (op->uo, loc_params, op->uvlid, name, type_id, lcpl_id,
+        tp->uo = H5VLdatatype_commit (op->uo, loc_params, op->uvlid, iname, type_id, lcpl_id,
                                       tcpl_id, tapl_id, dxpl_id, ureqp);
         CHECK_PTR (tp->uo);
 
@@ -72,9 +74,14 @@ void *H5VL_log_datatype_commit (void *obj,
     }
     H5VL_LOGI_EXP_CATCH
 
+    if (iname && iname != name) { free (iname); }
+
     return (void *)tp;
+
 err_out:;
     if (tp) { delete tp; }
+    if (iname && iname != name) { free (iname); }
+
     return NULL;
 } /* end H5VL_log_datatype_commit() */
 
@@ -98,10 +105,11 @@ void *H5VL_log_datatype_open (void *obj,
     H5VL_log_obj_t *tp = NULL;
     H5VL_log_req_t *rp;
     void **ureqp, *ureq;
+    char *iname = NULL;  // Internal name of object
 
     try {
-        /* Check arguments */
-        H5VL_LOGI_CHECK_NAME (name);
+        /* Rename user objects to avoid conflict with internal object */
+        iname = H5VL_logi_name_remap (name);
 
         tp = new H5VL_log_obj_t (op, H5I_DATATYPE);
 
@@ -112,7 +120,7 @@ void *H5VL_log_datatype_open (void *obj,
             ureqp = NULL;
         }
 
-        tp->uo = H5VLdatatype_open (op->uo, loc_params, op->uvlid, name, tapl_id, dxpl_id, ureqp);
+        tp->uo = H5VLdatatype_open (op->uo, loc_params, op->uvlid, iname, tapl_id, dxpl_id, ureqp);
         CHECK_PTR (tp->uo);
 
         if (req) {
@@ -122,10 +130,13 @@ void *H5VL_log_datatype_open (void *obj,
     }
     H5VL_LOGI_EXP_CATCH
 
+    if (iname && iname != name) { free (iname); }
+
     return (void *)tp;
 
 err_out:;
     if (tp) { delete tp; }
+    if (iname && iname != name) { free (iname); }
 
     return NULL;
 } /* end H5VL_log_datatype_open() */

--- a/src/H5VL_log_file.cpp
+++ b/src/H5VL_log_file.cpp
@@ -66,9 +66,6 @@ void *H5VL_log_file_create (
         }
 #endif
 
-        /* Check arguments */
-        H5VL_LOGI_CHECK_NAME (name);
-
         fp = H5VL_log_filei_search (name);
         if (fp) {
             fp = NULL;
@@ -277,9 +274,6 @@ void *H5VL_log_file_open (
             printf ("H5VL_log_file_open(%s, %u, fapl_id, dxpl_id, %p)\n", name, flags, req);
         }
 #endif
-
-        /* Check arguments */
-        H5VL_LOGI_CHECK_NAME (name);
 
         fp = H5VL_log_filei_search (name);
         if (fp) {

--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -184,9 +184,11 @@ herr_t H5VL_log_filei_dset_visit (hid_t o_id,
     hid_t did  = -1;  // Target dataset ID
 
     // Skip unnamed and hidden object
-    if ((name == NULL) || (name[0] == '_') || (name[0] == '/' || (name[0] == '.'))) {
+    if ((name == NULL) || (name[0] == '_' && name[1] != '_') ||
+        (name[0] == '/' || (name[0] == '.'))) {
         goto err_out;
     }
+    if (name[0] == '_') name++;
 
     try {
         // Open the dataset so that the dset metadata is cached in the file

--- a/src/H5VL_log_filei.hpp
+++ b/src/H5VL_log_filei.hpp
@@ -17,10 +17,10 @@
 #define H5VL_FILEI_CONFIG_DATA_ALIGN 0x100
 #define H5VL_FILEI_CONFIG_SUBFILING  0x200
 
-#define H5VL_LOG_FILEI_GROUP_LOG "__LOG"
-#define H5VL_LOG_FILEI_ATTR_INT  "__int_att"
-#define H5VL_LOG_FILEI_DSET_META "__md"
-#define H5VL_LOG_FILEI_DSET_DATA "__ld"
+#define H5VL_LOG_FILEI_GROUP_LOG "_LOG"
+#define H5VL_LOG_FILEI_ATTR_INT  "_int_att"
+#define H5VL_LOG_FILEI_DSET_META "_md"
+#define H5VL_LOG_FILEI_DSET_DATA "_ld"
 
 // File internals
 

--- a/src/H5VL_log_link.cpp
+++ b/src/H5VL_log_link.cpp
@@ -16,6 +16,7 @@
 #include "H5VL_log_obj.hpp"
 #include "H5VL_log_req.hpp"
 #include "H5VL_logi.hpp"
+#include "H5VL_logi_util.hpp"
 
 /********************* */
 /* Function prototypes */
@@ -215,6 +216,10 @@ herr_t H5VL_log_link_move (void *src_obj,
     herr_t err            = 0;
     H5VL_log_req_t *rp;
     void **ureqp, *ureq;
+    char *iname1               = NULL;  // Internal name of object
+    const char *original_name1 = NULL;  // Original value in loc_params before being remapped
+    char *iname2               = NULL;  // Internal name of object
+    const char *original_name2 = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -231,10 +236,10 @@ herr_t H5VL_log_link_move (void *src_obj,
         // Block access to internal objects
         switch (loc_params1->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params1->loc_data.loc_by_name.name) ||
-                    loc_params1->loc_data.loc_by_name.name[0] == '_') {
-                    RET_ERR ("Access to internal objects denied")
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name1 = loc_params1->loc_data.loc_by_name.name;
+                iname1         = H5VL_logi_name_remap (original_name1);
+                ((H5VL_loc_params_t *)loc_params1)->loc_data.loc_by_name.name = iname1;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -245,10 +250,10 @@ herr_t H5VL_log_link_move (void *src_obj,
         }
         switch (loc_params2->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params2->loc_data.loc_by_name.name) ||
-                    loc_params2->loc_data.loc_by_name.name[0] == '_') {
-                    RET_ERR ("Access to internal objects denied")
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name2 = loc_params2->loc_data.loc_by_name.name;
+                iname2         = H5VL_logi_name_remap (original_name2);
+                ((H5VL_loc_params_t *)loc_params2)->loc_data.loc_by_name.name = iname2;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -277,6 +282,16 @@ herr_t H5VL_log_link_move (void *src_obj,
     H5VL_LOGI_EXP_CATCH_ERR
 
 err_out:;
+    if (iname1 && iname1 != original_name1) { free (iname1); }
+    // Restore name in loc_param
+    if (original_name1) {
+        ((H5VL_loc_params_t *)loc_params1)->loc_data.loc_by_name.name = original_name1;
+    }
+    if (iname2 && iname2 != original_name2) { free (iname2); }
+    // Restore name in loc_param
+    if (original_name2) {
+        ((H5VL_loc_params_t *)loc_params2)->loc_data.loc_by_name.name = original_name2;
+    }
     return err;
 } /* end H5VL_log_link_move() */
 
@@ -299,6 +314,8 @@ herr_t H5VL_log_link_get (void *obj,
     herr_t err        = 0;
     H5VL_log_req_t *rp;
     void **ureqp, *ureq;
+    char *iname               = NULL;  // Internal name of object
+    const char *original_name = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -315,10 +332,10 @@ herr_t H5VL_log_link_get (void *obj,
         // Block access to internal objects
         switch (loc_params->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params->loc_data.loc_by_name.name) ||
-                    loc_params->loc_data.loc_by_name.name[0] == '_') {
-                    RET_ERR ("Access to internal objects denied")
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name = loc_params->loc_data.loc_by_name.name;
+                iname         = H5VL_logi_name_remap (original_name);
+                ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = iname;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -339,6 +356,11 @@ herr_t H5VL_log_link_get (void *obj,
     H5VL_LOGI_EXP_CATCH_ERR
 
 err_out:;
+    if (iname && iname != original_name) { free (iname); }
+    // Restore name in loc_param
+    if (original_name) {
+        ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = original_name;
+    }
     return err;
 } /* end H5VL_log_link_get() */
 
@@ -362,6 +384,8 @@ herr_t H5VL_log_link_specific (void *obj,
     H5VL_log_req_t *rp;
     void **ureqp, *ureq;
     H5VL_log_linki_iterate_op_data *ctx = NULL;
+    char *iname                         = NULL;  // Internal name of object
+    const char *original_name = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -378,15 +402,10 @@ herr_t H5VL_log_link_specific (void *obj,
         // Block access to internal objects
         switch (loc_params->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params->loc_data.loc_by_name.name) ||
-                    loc_params->loc_data.loc_by_name.name[0] == '_') {
-                    if (args->op_type == H5VL_LINK_EXISTS) {
-                        *args->args.exists.exists = false;
-                        goto err_out;
-                    } else {
-                        RET_ERR ("Access to internal objects denied")
-                    }
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name = loc_params->loc_data.loc_by_name.name;
+                iname         = H5VL_logi_name_remap (original_name);
+                ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = iname;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -423,6 +442,11 @@ herr_t H5VL_log_link_specific (void *obj,
 
 err_out:;
     if (ctx) { free (ctx); }
+    if (iname && iname != original_name) { free (iname); }
+    // Restore name in loc_param
+    if (original_name) {
+        ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = original_name;
+    }
     return err;
 } /* end H5VL_log_link_specific() */
 
@@ -445,6 +469,8 @@ herr_t H5VL_log_link_optional (void *obj,
     herr_t err        = 0;
     H5VL_log_req_t *rp;
     void **ureqp, *ureq;
+    char *iname               = NULL;  // Internal name of object
+    const char *original_name = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -461,10 +487,10 @@ herr_t H5VL_log_link_optional (void *obj,
         // Block access to internal objects
         switch (loc_params->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params->loc_data.loc_by_name.name) ||
-                    loc_params->loc_data.loc_by_name.name[0] == '_') {
-                    RET_ERR ("Access to internal objects denied")
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name = loc_params->loc_data.loc_by_name.name;
+                iname         = H5VL_logi_name_remap (original_name);
+                ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = iname;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -485,5 +511,10 @@ herr_t H5VL_log_link_optional (void *obj,
     H5VL_LOGI_EXP_CATCH_ERR
 
 err_out:;
+    if (iname && iname != original_name) { free (iname); }
+    // Restore name in loc_param
+    if (original_name) {
+        ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = original_name;
+    }
     return err;
 } /* end H5VL_log_link_optional() */

--- a/src/H5VL_log_linki.cpp
+++ b/src/H5VL_log_linki.cpp
@@ -19,9 +19,11 @@ herr_t H5VL_log_linki_iterate_op (hid_t group,
     // Skip internal objects
     if (name) {
         if (name[0] == '_') {
-            if (name[1] == '_') name++;
-        } else {
-            return 0;
+            if (name[1] == '_')
+                name++;
+            else {
+                return 0;
+            }
         }
         return ctx->op (group, name, info, ctx->op_data);
     }

--- a/src/H5VL_log_linki.cpp
+++ b/src/H5VL_log_linki.cpp
@@ -17,7 +17,12 @@ herr_t H5VL_log_linki_iterate_op (hid_t group,
     H5VL_log_linki_iterate_op_data *ctx = (H5VL_log_linki_iterate_op_data *)op_data;
 
     // Skip internal objects
-    if (name && (name[0] != '_' || name[1] != '_')) {
+    if (name) {
+        if (name[0] == '_') {
+            if (name[1] == '_') name++;
+        } else {
+            return 0;
+        }
         return ctx->op (group, name, info, ctx->op_data);
     }
 

--- a/src/H5VL_log_obj.cpp
+++ b/src/H5VL_log_obj.cpp
@@ -13,6 +13,7 @@
 #include "H5VL_log_obj.hpp"
 #include "H5VL_log_obji.hpp"
 #include "H5VL_logi.hpp"
+#include "H5VL_logi_util.hpp"
 
 /********************* */
 /* Function prototypes */
@@ -125,8 +126,10 @@ herr_t H5VL_log_object_get (void *obj,
                             H5VL_object_get_args_t *args,
                             hid_t dxpl_id,
                             void **req) {
-    herr_t err         = 0;
-    H5VL_log_obj_t *op = (H5VL_log_obj_t *)obj;
+    herr_t err                = 0;
+    H5VL_log_obj_t *op        = (H5VL_log_obj_t *)obj;
+    char *iname               = NULL;  // Internal name of object
+    const char *original_name = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -138,10 +141,10 @@ herr_t H5VL_log_object_get (void *obj,
         // Block access to internal objects
         switch (loc_params->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params->loc_data.loc_by_name.name) ||
-                    loc_params->loc_data.loc_by_name.name[0] == '_') {
-                    RET_ERR ("Access to internal objects denied")
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name = loc_params->loc_data.loc_by_name.name;
+                iname         = H5VL_logi_name_remap (original_name);
+                ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = iname;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -157,6 +160,11 @@ herr_t H5VL_log_object_get (void *obj,
     H5VL_LOGI_EXP_CATCH_ERR
 
 err_out:;
+    if (iname && iname != original_name) { free (iname); }
+    // Restore name in loc_param
+    if (original_name) {
+        ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = original_name;
+    }
     return err;
 } /* end H5VL_log_object_get() */
 
@@ -178,6 +186,8 @@ herr_t H5VL_log_object_specific (void *obj,
     herr_t err                         = 0;
     H5VL_log_obj_t *op                 = (H5VL_log_obj_t *)obj;
     H5VL_log_obji_iterate_op_data *ctx = NULL;
+    char *iname                        = NULL;  // Internal name of object
+    const char *original_name = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -190,15 +200,10 @@ herr_t H5VL_log_object_specific (void *obj,
         // Block access to internal objects
         switch (loc_params->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params->loc_data.loc_by_name.name) ||
-                    loc_params->loc_data.loc_by_name.name[0] == '_') {
-                    if (args->op_type == H5VL_OBJECT_EXISTS) {
-                        *args->args.exists.exists = false;
-                        goto err_out;
-                    } else {
-                        RET_ERR ("Access to internal objects denied")
-                    }
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name = loc_params->loc_data.loc_by_name.name;
+                iname         = H5VL_logi_name_remap (original_name);
+                ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = iname;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -229,6 +234,11 @@ herr_t H5VL_log_object_specific (void *obj,
 
 err_out:;
     if (ctx) { free (ctx); }
+    if (iname && iname != original_name) { free (iname); }
+    // Restore name in loc_param
+    if (original_name) {
+        ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = original_name;
+    }
     return err;
 } /* end H5VL_log_object_specific() */
 
@@ -247,8 +257,10 @@ herr_t H5VL_log_object_optional (void *obj,
                                  H5VL_optional_args_t *args,
                                  hid_t dxpl_id,
                                  void **req) {
-    herr_t err         = 0;
-    H5VL_log_obj_t *op = (H5VL_log_obj_t *)obj;
+    herr_t err                = 0;
+    H5VL_log_obj_t *op        = (H5VL_log_obj_t *)obj;
+    char *iname               = NULL;  // Internal name of object
+    const char *original_name = NULL;  // Original value in loc_params before being remapped
 
     try {
 #ifdef LOGVOL_DEBUG
@@ -260,10 +272,10 @@ herr_t H5VL_log_object_optional (void *obj,
         // Block access to internal objects
         switch (loc_params->type) {
             case H5VL_OBJECT_BY_NAME:
-                if (!(loc_params->loc_data.loc_by_name.name) ||
-                    loc_params->loc_data.loc_by_name.name[0] == '_') {
-                    RET_ERR ("Access to internal objects denied")
-                }
+                /* Rename user objects to avoid conflict with internal object */
+                original_name = loc_params->loc_data.loc_by_name.name;
+                iname         = H5VL_logi_name_remap (original_name);
+                ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = iname;
                 break;
             case H5VL_OBJECT_BY_SELF:
                 break;
@@ -279,5 +291,10 @@ herr_t H5VL_log_object_optional (void *obj,
     H5VL_LOGI_EXP_CATCH_ERR
 
 err_out:;
+    if (iname && iname != original_name) { free (iname); }
+    // Restore name in loc_param
+    if (original_name) {
+        ((H5VL_loc_params_t *)loc_params)->loc_data.loc_by_name.name = original_name;
+    }
     return err;
 } /* end H5VL_log_object_optional() */

--- a/src/H5VL_log_obji.cpp
+++ b/src/H5VL_log_obji.cpp
@@ -23,7 +23,12 @@ herr_t H5VL_log_obji_iterate_op (hid_t obj,
     H5VL_log_obji_iterate_op_data *ctx = (H5VL_log_obji_iterate_op_data *)op_data;
 
     // Skip internal objects
-    if (name && (name[0] != '_' || name[1] != '_')) {
+    if (name) {
+        if (name[0] == '_') {
+            if (name[1] == '_') name++;
+        } else {
+            return 0;
+        }
         return ctx->op (obj, name, info, ctx->op_data);
     }
 

--- a/src/H5VL_log_obji.cpp
+++ b/src/H5VL_log_obji.cpp
@@ -25,9 +25,11 @@ herr_t H5VL_log_obji_iterate_op (hid_t obj,
     // Skip internal objects
     if (name) {
         if (name[0] == '_') {
-            if (name[1] == '_') name++;
-        } else {
-            return 0;
+            if (name[1] == '_')
+                name++;
+            else {
+                return 0;
+            }
         }
         return ctx->op (obj, name, info, ctx->op_data);
     }

--- a/src/H5VL_logi_util.hpp
+++ b/src/H5VL_logi_util.hpp
@@ -91,7 +91,7 @@ inline char *H5VL_logi_name_remap (const char *name) {
     int n;
     char *ret;
 
-    n == strlen (name);
+    n = strlen (name);
 
     if (n == 0) { ERR_OUT ("Object name cannot be empty") }
     if (name[0] == '_') {

--- a/src/H5VL_logi_util.hpp
+++ b/src/H5VL_logi_util.hpp
@@ -86,3 +86,21 @@ inline void H5VL_logi_lreverse (uint32_t *start, uint32_t *end) {
 inline void H5VL_logi_llreverse (uint64_t *start, uint64_t *end) {
     for (; start < end; start++) { H5VL_logi_llreverse (start); }
 }
+
+inline char *H5VL_logi_name_remap (const char *name) {
+    int n;
+    char *ret;
+
+    n == strlen (name);
+
+    if (n == 0) { ERR_OUT ("Object name cannot be empty") }
+    if (name[0] == '_') {
+        ret    = (char *)malloc (n + 2);
+        ret[0] = '_';
+        strncpy (ret + 1, name, n + 1);
+    } else {
+        ret = (char *)name;
+    }
+
+    return ret;
+}

--- a/utils/h5ldump/h5ldump.cpp
+++ b/utils/h5ldump/h5ldump.cpp
@@ -279,7 +279,7 @@ void h5ldump_file (std::string path,
         }
     } else {
         // Open the log group
-        lgid = H5Gopen2 (fid, "__LOG", H5P_DEFAULT);
+        lgid = H5Gopen2 (fid, H5VL_LOG_FILEI_GROUP_LOG, H5P_DEFAULT);
         CHECK_ID (lgid)
         if (lgid < 0) {
             std::cout << "Error: " << path << " is not a valid log-based VOL file." << std::endl;

--- a/utils/h5ldump/h5ldump_visit.cpp
+++ b/utils/h5ldump/h5ldump_visit.cpp
@@ -73,7 +73,7 @@ herr_t h5ldump_visit_handler (hid_t o_id,
     std::vector<H5VL_log_dset_info_t> *dsets = (std::vector<H5VL_log_dset_info_t> *)op_data;
 
     // Skip unnamed and hidden object
-    if ((name == NULL) || (name[0] == '_' && name[1] == '_') ||
+    if ((name == NULL) || (name[0] == '_' && name[1] != '_') ||
         (name[0] == '/' || (name[0] == '.'))) {
         goto err_out;
     }

--- a/utils/h5lreplay/h5lreplay_copy.cpp
+++ b/utils/h5lreplay/h5lreplay_copy.cpp
@@ -35,7 +35,8 @@ herr_t h5lreplay_copy_handler (hid_t o_id,
     h5lreplay_copy_handler_arg *argp = (h5lreplay_copy_handler_arg *)op_data;
 
     // Skip unnamed and hidden object
-    if ((name == NULL) || (name[0] == '_') || (name[0] == '/' || (name[0] == '.'))) {
+    if ((name == NULL) || (name[0] == '_' && name[1] != '_') ||
+        (name[0] == '/' || (name[0] == '.'))) {
 #ifdef LOGVOL_DEBUG
         if (name[0] == '_') {
             std::cout << "Skip log-based VOL data objects " << name << std::endl;
@@ -43,6 +44,7 @@ herr_t h5lreplay_copy_handler (hid_t o_id,
 #endif
         goto err_out;
     }
+    if (name[0] == '_') name++;
 
     try {
         // Copy a dataset
@@ -176,7 +178,7 @@ herr_t h5lreplay_attr_copy_handler (hid_t location_id,
     void *buf = NULL;
 
     // Skip unnamed and hidden object
-    if ((attr_name == NULL) || (attr_name[0] == '_') ||
+    if ((attr_name == NULL) || (attr_name[0] == '_' && attr_name[1] != '_') ||
         (attr_name[0] == '/' || (attr_name[0] == '.'))) {
 #ifdef LOGVOL_DEBUG
         if (attr_name[0] == '_') {
@@ -185,6 +187,7 @@ herr_t h5lreplay_attr_copy_handler (hid_t location_id,
 #endif
         goto err_out;
     }
+    if (attr_name[0] == '_') attr_name++;
 
     try {
 #ifdef LOGVOL_DEBUG


### PR DESCRIPTION
Use single '_' for internal object prefix
Rename user objects named _* to __* to avoid conflict with internal objects.
