### PR TITLE
Change subfiling default setting

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -66,12 +66,12 @@ HDF5 environment variables.
      ```
 
 ### Enable log-based VOL subfiling feature
-Subfiling is a feature to mitigate the file lock conflict in a parallel file
-write operation. It divides MPI processes into groups disjointedly and creates
-one file per group, thus named subfiling. Each subfile is shared only among
-the processes in the same group and contains data written by those processes
+Subfiling is a feature to mitigate the file lock conflict in a parallel write
+operation to a shared file. It divides MPI processes into groups disjointedly
+and creates one file (named subfile) per group. Each subfile is accessible only
+to the processes in the same group and contains data written by those processes
 only. By reducing the number of MPI processes sharing a file, subfiling reduces
-the file access conflicts and hence effectively improves the degree of I/O
+the file access contentions, and hence effectively improves the degree of I/O
 parallelism.
 
 * Enabling subfiling through an environment variable
@@ -80,21 +80,26 @@ parallelism.
     ```
     % export H5VL_LOG_NSUBFILES=2
     ```
-  + If the environment variable is set without a value or with a non-positive value
-    , then the number of subfiles will be set to equal to the number of compute 
-    nodes allocated.
+  + If the environment variable is set without a value or with a non-positive
+    value, then the number of subfiles will be set to equal to the number of
+    compute nodes allocated.
     ```
     % export H5VL_LOG_NSUBFILES=
     ```
+  + If the environment variable is not set or set to 0, then the subfiling is
+    disabled.
 * Output file structure and naming scheme.
   * A master file (whose file name is supplied by the user to `H5Fcreate`)
-    + Stores user datasets, attributes ... etc.
-  * A directory containing all the subfiles.
+    contains:
+    + User attributes.
+    + User datasets as scalars. The contents of datasets are stored in the
+      subfiles.
+  * A new directory containing all the subfiles.
     + The directory is named `<master_file_name>.subfiles`.
   * Subfiles
     + Each subfile is named `<master_file_name>.id` where `id` is the ID
       starting from 0 to the number of subfiles minus one.
-    + Each subfile stores the log data.
+    + Each subfile stores the log data of all partitioned datasets.
 
 ### Differences from the native VOL
   * Buffered and non-buffered modes

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -28,18 +28,18 @@ This is essentially a placeholder for the next release note ...
   + H5Pget/set_subfiling property type changed to int
     + Signature
       ```
-        herr_t H5Pset_subfiling (hid_t plist, int nsubfiles);
-        herr_t H5Pget_subfiling (hid_t plist, int *nsubfiles);
+        herr_t H5Pset_subfiling (hid_t fcplid, int  nsubfiles);
+        herr_t H5Pget_subfiling (hid_t fcplid, int *nsubfiles);
       ```
-    + Allows setting number of subfiles in addition to enabling subfiling
-    + Meaning of argument "nsubfiles"
-      + 1 (H5VL_LOG_SUBFILING_OFF): Disable subfiling
-      + Non-positive values (H5VL_LOG_SUBFILING_FILE_PER_NODE): One subfile per node
-      + Positive value larger than 1: Create "nsubfiles" subfiles
+      `fcplid` is the file creation preperty list ID.
+    + Allows setting the number of subfiles including disabling/enabling subfiling.
+      + When nsubfiles is 0: disable subfiling.
+      + When nsubfiles is a negative values: one subfile per computer node.
+      + When nsubfiles is a positive value: create "nsubfiles" subfiles.
 
-* Run-time environment variables changes
-  + The meaning of H5VL_LOG_NSUBFILES is changed to match argument "nsubfiles" in H5Pget/set_subfiling
-    + See API syntax changes section for more information
+* Run-time environment variables
+  + Environment variable `H5VL_LOG_NSUBFILES` has been changed to match the
+    argument "nsubfiles" in API `H5Pget/set_subfiling` described above.
 
 * API semantics updates
   + Remove the restriction that does not allow user objects with a name starting with '_'

--- a/src/H5VL_log.cpp
+++ b/src/H5VL_log.cpp
@@ -642,7 +642,6 @@ herr_t H5Pget_subfiling (hid_t plist, int *nsubfiles) {
             if (pexist) {
                 err = H5Pget (plist, SUBFILING_PROPERTY_NAME, nsubfiles);
                 CHECK_ERR
-
             } else {
                 *nsubfiles = H5VL_LOG_SUBFILING_OFF;
             }

--- a/src/H5VL_log.h.in
+++ b/src/H5VL_log.h.in
@@ -29,7 +29,7 @@ extern "C" {
 // Constants
 #define LOG_VOL_BSIZE_UNLIMITED -1
 #define H5S_CONTIG				H5S_BLOCK	// H5S_CONTIG serves the purpose of H5S_BLOCK before HDF5 introduces it
-#define H5VL_LOG_SUBFILING_OFF 1
+#define H5VL_LOG_SUBFILING_OFF 0
 #define H5VL_LOG_SUBFILING_FILE_PER_NODE 0
 
 typedef enum H5VL_log_req_type_t {


### PR DESCRIPTION
When H5VL_LOG_NSUBFILES is 0, subfiling is disabled.
When H5VL_LOG_NSUBFILES is not set, subfiling is disabled.
WHen H5VL_LOG_NSUBFILES is negative, one subfile per compute node.
WHen H5VL_LOG_NSUBFILES is set without a value, one subfile per compute node.

The above applies to the argument nsubfiles of API
H5Pset_subfiling (hid_t fcplid, int nsubfiles)