### PR TITLE
Fix unrecognized pointer bug when reading regular HDF5 files

### DIFF
--- a/src/H5VL_log_obj.cpp
+++ b/src/H5VL_log_obj.cpp
@@ -75,7 +75,7 @@ void *H5VL_log_object_open (void *obj,
                 ret = H5VL_log_obj_open_with_uo (obj, uo, *opened_type, loc_params);
             }
         } else {
-            ret = uo;
+            ret = new H5VL_log_obj_t (op, *opened_type, uo);
         }
     }
     H5VL_LOGI_EXP_CATCH

--- a/src/H5VL_log_wrap.cpp
+++ b/src/H5VL_log_wrap.cpp
@@ -114,7 +114,11 @@ void *H5VL_log_wrap_object (void *obj, H5I_type_t type, void *_wrap_ctx) {
 
         /* Wrap the object with the underlying VOL */
         uo = H5VLwrap_object (obj, type, ctx->uvlid, ctx->uo);
-        if (uo) {
+
+        if (!ctx->fp->is_log_based_file) {
+            wop = new H5VL_log_obj_t (ctx, type, uo);
+        }
+        else if (uo) {
             if (type == H5I_DATASET) {
                 wop = (H5VL_log_obj_t *)H5VL_log_dataseti_wrap (uo, ctx);
             } else if (type == H5I_FILE) {
@@ -153,7 +157,11 @@ void *H5VL_log_unwrap_object (void *obj) {
         /* Unrap the object with the underlying VOL */
         uo = H5VLunwrap_object (op->uo, op->uvlid);
 
-        if (uo) {
+        if (!op->fp->is_log_based_file) {
+            uo = H5VLunwrap_object (op->uo, op->uvlid);
+            if (op->fp != op) delete op;
+        }
+        else if (uo) {
             hid_t err_id;
 
             err_id = H5Eget_current_stack ();


### PR DESCRIPTION
Fix the unrecognized pointer bug when reading regular HDF5 files.
Now, calling ncdump on a regular NetCDF-4 file won't fail.