### PR TITLE
Use a non-default dxplid to collectively write datasets and metada datasets.

### DIFF
--- a/src/H5VL_log_file.cpp
+++ b/src/H5VL_log_file.cpp
@@ -529,7 +529,7 @@ herr_t H5VL_log_file_specific (void *file,
                     // Reset hdf5 context to allow dataset operations within a file operation
                     H5VL_logi_reset_lib_stat (lib_state);
 
-                    H5VL_log_nb_flush_write_reqs (fp, dxpl_id);
+                    H5VL_log_nb_flush_write_reqs (fp);
                 } else {
                     err = H5VLfile_specific (fp->uo, fp->uvlid, args, dxpl_id, req);
                 }

--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -569,7 +569,7 @@ void H5VL_log_filei_flush (H5VL_log_file_t *fp, hid_t dxplid) {
         if (fp->config & H5VL_FILEI_CONFIG_DATA_ALIGN) {
             H5VL_log_nb_flush_write_reqs_align (fp, dxplid);
         } else {
-            H5VL_log_nb_flush_write_reqs (fp, dxplid);
+            H5VL_log_nb_flush_write_reqs (fp);
         }
     }
 
@@ -636,7 +636,7 @@ void H5VL_log_filei_close (H5VL_log_file_t *fp) {
         if (fp->config & H5VL_FILEI_CONFIG_DATA_ALIGN) {
             H5VL_log_nb_flush_write_reqs_align (fp, fp->dxplid);
         } else {
-            H5VL_log_nb_flush_write_reqs (fp, fp->dxplid);
+            H5VL_log_nb_flush_write_reqs (fp);
         }
 
         // Generate metadata table

--- a/src/H5VL_logi_nb.cpp
+++ b/src/H5VL_logi_nb.cpp
@@ -531,7 +531,7 @@ void H5VL_log_nb_flush_read_reqs (void *file, std::vector<H5VL_log_rreq_t *> &re
     err = H5Pget_dxpl_mpio (dxplid, &xfer_mode);
     CHECK_ERR
     if ((xfer_mode == H5FD_MPIO_COLLECTIVE) || fp->np == 1) {
-        H5VL_log_nb_flush_write_reqs (fp, dxplid);
+        H5VL_log_nb_flush_write_reqs (fp);
     }
 
     H5VL_LOGI_PROFILING_TIMER_START;
@@ -595,7 +595,7 @@ void H5VL_log_nb_flush_read_reqs (void *file, std::vector<H5VL_log_rreq_t *> &re
     H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VL_LOG_NB_FLUSH_READ_REQS);
 }
 
-void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
+void H5VL_log_nb_flush_write_reqs (void *file) {
     herr_t err = 0;
     int mpierr;
     int i, j;
@@ -613,7 +613,7 @@ void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
     // void *vldp;				 // Handle to the log dataset
     hid_t ldsid  = -1;  // Space of the log dataset
     hid_t dcplid = -1;  // log dataset creation property ID
-    hid_t new_dxplid = -1;  // log dataset transfer property ID
+    hid_t dxplid = -1;  // log dataset transfer property ID
     // hid_t vldsid  = -1;			  // Space of the virtual log dataset in the main
     // file hid_t vdcplid = -1;	 // Virtual log dataset creation property list
     hsize_t start;  // Size for dataspace selection
@@ -623,12 +623,12 @@ void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
     char dname[16];  // Name of the log dataset
     H5VL_log_file_t *fp       = (H5VL_log_file_t *)file;
     bool perform_write_in_mpi = true;
-    H5VL_logi_err_finally finally ([&mtype, &ldsid, &dcplid, &new_dxplid, &mlens, &moffs] () -> void {
+    H5VL_logi_err_finally finally ([&mtype, &ldsid, &dcplid, &dxplid, &mlens, &moffs] () -> void {
         if (mtype != MPI_DATATYPE_NULL) MPI_Type_free (&mtype);
         H5VL_log_Sclose (ldsid);
         // H5VL_log_Sclose (vldsid);
         H5VL_log_Pclose (dcplid);
-        H5VL_log_Pclose (new_dxplid);
+        H5VL_log_Pclose (dxplid);
 
         H5VL_log_free (mlens);
         H5VL_log_free (moffs);
@@ -739,15 +739,15 @@ void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
             err = H5Pset_alloc_time (dcplid, H5D_ALLOC_TIME_EARLY);
 
             // set up transfer property list; using collective MPI IO
-            new_dxplid = H5Pcreate(H5P_DATASET_XFER);
-            CHECK_ID(new_dxplid);
-            H5Pset_dxpl_mpio(new_dxplid, H5FD_MPIO_COLLECTIVE);
+            dxplid = H5Pcreate(H5P_DATASET_XFER);
+            CHECK_ID(dxplid);
+            H5Pset_dxpl_mpio(dxplid, H5FD_MPIO_COLLECTIVE);
 
             // Create dataset with under VOL
             H5VL_LOGI_PROFILING_TIMER_START;
             ldp = H5VLdataset_create (fp->lgp, &loc, fp->uvlid, dname, H5P_LINK_CREATE_DEFAULT,
                                       H5T_STD_B8LE, ldsid, dcplid, H5P_DATASET_ACCESS_DEFAULT,
-                                      new_dxplid, NULL);
+                                      dxplid, NULL);
 
             H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VLDATASET_CREATE);
             CHECK_PTR (ldp);
@@ -756,29 +756,29 @@ void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
 
             H5VL_LOGI_PROFILING_TIMER_START;
             // Get dataset file offset
-            H5VL_logi_dataset_get_foff (fp, ldp, fp->uvlid, new_dxplid, &doff);
+            H5VL_logi_dataset_get_foff (fp, ldp, fp->uvlid, dxplid, &doff);
             // If not allocated, flush the file and reopen the dataset
             if (doff == HADDR_UNDEF) {
                 H5VL_file_specific_args_t arg;
 
                 // Close the dataset
-                err = H5VLdataset_close (ldp, fp->uvlid, new_dxplid, NULL);
+                err = H5VLdataset_close (ldp, fp->uvlid, dxplid, NULL);
                 CHECK_ERR
 
                 // Flush the file
                 arg.op_type             = H5VL_FILE_FLUSH;
                 arg.args.flush.scope    = H5F_SCOPE_GLOBAL;
                 arg.args.flush.obj_type = H5I_FILE;
-                err                     = H5VLfile_specific (fp->uo, fp->uvlid, &arg, new_dxplid, NULL);
+                err                     = H5VLfile_specific (fp->uo, fp->uvlid, &arg, dxplid, NULL);
                 CHECK_ERR
 
                 // Reopen the dataset
                 ldp = H5VLdataset_open (fp->lgp, &loc, fp->uvlid, dname, H5P_DATASET_ACCESS_DEFAULT,
-                                        new_dxplid, NULL);
+                                        dxplid, NULL);
                 CHECK_PTR (ldp);
 
                 // Get dataset file offset
-                H5VL_logi_dataset_get_foff (fp, ldp, fp->uvlid, new_dxplid, &doff);
+                H5VL_logi_dataset_get_foff (fp, ldp, fp->uvlid, dxplid, &doff);
 
                 // Still don't work, discard the data
                 if (doff == HADDR_UNDEF) {
@@ -823,7 +823,7 @@ void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
 
                 H5VL_LOGI_PROFILING_TIMER_START;
                 err = H5VLdataset_write (ldp, fp->uvlid, H5T_STD_B8LE, mspace_id, ldsid,
-                                         new_dxplid, (void *)mbuff, NULL);
+                                         dxplid, (void *)mbuff, NULL);
                 CHECK_ERR;
                 H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VL_LOG_NB_FLUSH_WRITE_REQS_WR);
                 free (mbuff);
@@ -831,7 +831,7 @@ void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid) {
             }
 
             // Close the dataset
-            err = H5VLdataset_close (ldp, fp->uvlid, new_dxplid, NULL);
+            err = H5VLdataset_close (ldp, fp->uvlid, dxplid, NULL);
             CHECK_ERR;
 
             // Update metadata in requests

--- a/src/H5VL_logi_nb.hpp
+++ b/src/H5VL_logi_nb.hpp
@@ -115,6 +115,6 @@ void H5VL_log_nb_flush_read_reqs (void *file, std::vector<H5VL_log_rreq_t *> &re
 void H5VL_log_nb_perform_read (H5VL_log_file_t *fp,
                                std::vector<H5VL_log_rreq_t *> &reqs,
                                hid_t dxplid);
-void H5VL_log_nb_flush_write_reqs (void *file, hid_t dxplid);
+void H5VL_log_nb_flush_write_reqs (void *file);
 void H5VL_log_nb_ost_write (void *file, off_t doff, off_t off, int cnt, int *mlens, off_t *moffs);
 void H5VL_log_nb_flush_write_reqs_align (void *file, hid_t dxplid);


### PR DESCRIPTION
Previously we were not able to use a non-default dxplid because of an issue related to lib state calls.

PR #41 fixed this issue so now we can use a non-default dxplid and setup collective MPIIO to write the datasets. 