### PR TITLE
Update RELEASE_NOTE.md for 1.4.0

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -6,9 +6,8 @@
   + Support NetCDF4. By setting the two VOL environment variables
     `HDF5_VOL_CONNECTOR` and `HDF5_PLUGIN_PATH`, NetCDF4 programs now can write
     data to files in log layout through Log VOL. See PR #15.
+  + Support opening and operating an existing regular HDF5 file.
   + Support using Log VOL as a Pass-through VOL.
-    * This feature adds the support of opening and operating an existing
-      regular HDF5 file.
     * This feature adds the option of performing all writes using the
       underlying VOL.
     * When the Pass-through VOL is enabled, it uses collective MPI I/O to

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -29,6 +29,10 @@
 * New Limitations
   + Log VOL currently does not support multiple opens of the same file.
 
+* Update configure options
+  + `--enable-test-threading` will enable test cases under `tests/basic` folder to initialize MPI with multi-thread support. i.e. use `MPI_Init_thread` instead of `MPI_Init`.
+  + `--enable-test-env-vars` will enable test cases under `tests/basic` folder to use the user-provided environment variables `HDF5_VOL_CONNECTOR` and `HDF5_PLUGIN_PATH` to decide the underlying VOL connectors. If disabled, these test cases will ignore the above two environment variables and use Log VOL only.
+
 * New APIs
   + H5Pget_passthru_read_write. See PR #33.
     + Signature

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -7,13 +7,10 @@
     `HDF5_VOL_CONNECTOR` and `HDF5_PLUGIN_PATH`, NetCDF4 programs now can write
     data to files in log layout through Log VOL. See PR #15.
   + Support opening and operating an existing regular HDF5 file.
-  + Support using Log VOL as a Pass-through VOL.
-    * This feature adds the option of performing all writes using the
-      underlying VOL.
-    * When the Pass-through VOL is enabled, it uses collective MPI I/O to
-      perform file writes. See PR #42.
+  + Support using Log VOL as a pass-through VOL when performing writes.
+    * Whe performing writes, users can specify and choose other VOL connectors as the underlying VOLs of Log VOL. See PR #33.
+    * When the pass-through feature is enabled, it asks the underlying VOLs to use collective MPI I/O. See PR #42.
     * For its usage, refer to the User Guide in doc/usage.md.
-    * See PR #33.
   + Support VOL connector interface version 3.
     * HDF5 1.13.3 requires a version 3 connector.
     * Log VOL will expose the version 3 interface when the HDF5 version 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,6 +1,6 @@
 ## Release Notes of the Log Layout Based HDF5 Virtual Object Layer
 
-### Version 1.4.0 (Dec 05, 2022)
+### Version 1.4.0 (Dec 15, 2022)
 * New features
   + Support fill mode. See commit 8aee024
   + Support NetCDF4. By setting the two VOL environment variables


### PR DESCRIPTION
Update/Mention the following two new config options in RELEASE_NOTE.md:
1. `--enable-test-threading` will enable test cases under `tests/basic` folder to initialize MPI with multi-thread support. i.e. use `MPI_Init_thread` instead of `MPI_Init`.
2. `--enable-test-env-vars` will enable test cases under `tests/basic` folder to use the user-provided environment variables `HDF5_VOL_CONNECTOR` and `HDF5_PLUGIN_PATH` to decide the underlying VOL connectors. If disabled, these test cases will ignore the above two environment variables and use Log VOL only.