### PR TITLE
fix bug: unnecessary in unwrap_object 

### DIFF
--- a/src/H5VL_log_wrap.cpp
+++ b/src/H5VL_log_wrap.cpp
@@ -156,8 +156,12 @@ void *H5VL_log_unwrap_object (void *obj) {
         if (H5VL_logi_debug_verbose ()) { printf ("H5VL_log_unwrap_object(%p)\n", obj); }
 #endif
         if (!op->fp->is_log_based_file) {
-            uo = H5VLunwrap_object (op->uo, op->uvlid);
-            if (op->fp != op) delete op;
+            if (op->fp != op) {
+                uo = H5VLunwrap_object (op->uo, op->uvlid);
+                delete op;
+            } else {
+                uo = op->fp->wrapped_obj;
+            }
         } else if (op->fp != op) {
             uo = H5VLunwrap_object (op->uo, op->uvlid);
             delete op;


### PR DESCRIPTION
When 1) reading a regular file and 2) stacking Log VOL on top of other VOLs, the `obj` passed to `H5VL_log_unwrap_object` may be freed twice. This bug is triggered when running E3SM_IO with Log VOL on top of Cache VOL and Async VOL.