### PR TITLE
Passthru read

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -4,13 +4,13 @@ This is essentially a placeholder for the next release note ...
 (Copy the contents below to RELEASE_NOTE.md when making an official release.)
 
 * New features
-  + none
+  + Support Passthru mode for read. See PR #61.
 
 * New optimization
   + none
 
 * New Limitations
-  + none
+  + When performing passthru read, only independent MPI mode is supported. See PR #61.
 
 * Update configure options
   + none
@@ -58,7 +58,7 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New test program
-  + none
+  + tests/passthru/col_read.cpp. This test program tests the non-blocking read feature when passthru mode is enabled.
 
 * Conformity with HDF5 library
   + none

--- a/src/H5VL_log_dataseti.cpp
+++ b/src/H5VL_log_dataseti.cpp
@@ -455,7 +455,7 @@ void H5VL_log_dataset_readi_passthru (std::vector<H5VL_log_idx_search_ret_t> &bl
     }
 }
 
-void H5VL_log_dataset_readi_gen_rtypes (std::vector<H5VL_log_idx_search_ret_t> blocks,
+void H5VL_log_dataset_readi_gen_rtypes (std::vector<H5VL_log_idx_search_ret_t> &blocks,
                                         MPI_Datatype *ftype,
                                         MPI_Datatype *mtype,
                                         std::vector<H5VL_log_copy_ctx> &overlaps) {

--- a/src/H5VL_log_dataseti.cpp
+++ b/src/H5VL_log_dataseti.cpp
@@ -212,12 +212,12 @@ void H5VL_log_dataset_readi_passthru (std::vector<H5VL_log_idx_search_ret_t> &bl
 
     dxplid = H5Pcreate (H5P_DATASET_XFER);
     CHECK_ID (dxplid);
-    fdid = H5Pget_driver (fp->ufaplid);
-    CHECK_ID (fdid)
-    if (fdid == H5FD_MPIO) {
-        err = H5Pset_dxpl_mpio (dxplid, H5FD_MPIO_COLLECTIVE);
-        CHECK_ERR;
-    }
+    // fdid = H5Pget_driver (fp->ufaplid);
+    // CHECK_ID (fdid)
+    // if (fdid == H5FD_MPIO) {
+    //     err = H5Pset_dxpl_mpio (dxplid, H5FD_MPIO_COLLECTIVE);
+    //     CHECK_ERR;
+    // }
 
     for (i = 0; i < fp->nldset; i++) {
         sprintf (dname, "%s_%d", H5VL_LOG_FILEI_DSET_DATA, i);

--- a/src/H5VL_log_dataseti.hpp
+++ b/src/H5VL_log_dataseti.hpp
@@ -33,7 +33,7 @@ typedef struct H5VL_log_copy_ctx {
 
 void *H5VL_log_dataseti_open (void *obj, void *uo, hid_t dxpl_id);
 void *H5VL_log_dataseti_wrap (void *uo, H5VL_log_obj_t *cp);
-void H5VL_log_dataset_readi_gen_rtypes (std::vector<H5VL_log_idx_search_ret_t> blocks,
+void H5VL_log_dataset_readi_gen_rtypes (std::vector<H5VL_log_idx_search_ret_t> &blocks,
                                         MPI_Datatype *ftype,
                                         MPI_Datatype *mtype,
                                         std::vector<H5VL_log_copy_ctx> &overlaps);

--- a/src/H5VL_log_dataseti.hpp
+++ b/src/H5VL_log_dataseti.hpp
@@ -51,6 +51,10 @@ void H5VL_log_dataseti_read (H5VL_log_dset_t *dp,
                              hid_t plist_id,
                              void *buf,
                              void **req);
+
+void H5VL_log_dataset_readi_passthru (std::vector<H5VL_log_idx_search_ret_t> &blocks,
+                                      std::vector<H5VL_log_copy_ctx> &overlaps,
+                                      H5VL_log_file_t *fp);
 /*
 herr_t H5VL_log_dataseti_writen (hid_t did,
                                   hid_t mem_type_id,

--- a/src/H5VL_log_file.cpp
+++ b/src/H5VL_log_file.cpp
@@ -447,7 +447,7 @@ herr_t H5VL_log_file_specific (void *file,
                     // Reset hdf5 context to allow dataset operations within a file operation
                     H5VL_logi_reset_lib_stat (lib_state);
 
-                    H5VL_log_nb_flush_write_reqs (fp);
+                    H5VL_log_filei_flush(fp, dxpl_id);
                 } else {
                     err = H5VLfile_specific (fp->uo, fp->uvlid, args, dxpl_id, req);
                 }

--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -657,18 +657,8 @@ void H5VL_log_filei_contig_buffer_alloc (H5VL_log_buffer_pool_t *p) {
 void H5VL_log_filei_flush (H5VL_log_file_t *fp, hid_t dxplid) {
     H5VL_LOGI_PROFILING_TIMER_START;
 
-    if (fp->wreqs.size () > 0) {
-        if (fp->config & H5VL_FILEI_CONFIG_DATA_ALIGN) {
-            H5VL_log_nb_flush_write_reqs_align (fp, dxplid);
-        } else {
-            H5VL_log_nb_flush_write_reqs (fp);
-        }
-    }
-
-    if (fp->rreqs.size () > 0) {
-        H5VL_log_nb_flush_read_reqs (fp, fp->rreqs, dxplid);
-        fp->rreqs.clear ();
-    }
+    H5VL_log_nb_flush_write_reqs (fp);
+    H5VL_log_nb_flush_read_reqs (fp, fp->rreqs, dxplid);
 
     H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VL_LOG_FILEI_FLUSH);
 }

--- a/src/H5VL_logi_util.hpp
+++ b/src/H5VL_logi_util.hpp
@@ -18,9 +18,9 @@
     H5VLdataset_write (1, &(uo), uvlid, &(mtid), &(msid), &(dsid), dxplid, (const void**)&(buf), NULL)
 #else
 #define H5VL_log_under_dataset_read(uo, uvlid, mtid, msid, dsid, dxplid, buf, req) \
-    H5VLdataset_read (uo, uvlid, mtid, msid, dsid, dxplid, buf, NULL)
+    H5VLdataset_read (uo, uvlid, mtid, msid, dsid, dxplid, (void*)buf, NULL)
 #define H5VL_log_under_dataset_write(uo, uvlid, mtid, msid, dsid, dxplid, buf, req) \
-    H5VLdataset_write (uo, uvlid, mtid, msid, dsid, dxplid, buf, NULL)
+    H5VLdataset_write (uo, uvlid, mtid, msid, dsid, dxplid, (void*)buf, NULL)
 #endif
 
 // Utils

--- a/tests/passthru/Makefile.am
+++ b/tests/passthru/Makefile.am
@@ -21,7 +21,7 @@ LDADD = $(top_builddir)/src/libH5VL_log.la ../common/libtestutils.la
 ../common/libtestutils.la:
 	set -e; cd ../common && $(MAKE) $(MFLAGS) tests
 
-check_PROGRAMS =  dwrite
+check_PROGRAMS =  dwrite col_read
 
 EXTRA_DIST = seq_runs.sh parallel_run.sh
 

--- a/tests/passthru/col_read.cpp
+++ b/tests/passthru/col_read.cpp
@@ -141,7 +141,7 @@ int main (int argc, char **argv) {
     /* File space setting */
     err = H5Sselect_hyperslab (filespace_id, H5S_SELECT_SET, start, NULL, count, NULL);
     CHECK_ERR (err);
-    err = H5Dread (did, H5T_NATIVE_INT, memspace_id, filespace_id, dxplid, buf + 4);
+    err = H5Dread (did, H5T_NATIVE_INT, memspace_id, filespace_id, dxplid, buf + np);
 
     for (i = 0; i < dims[1]; i++) {
         expected = get_expected (i, rank, 1, env.log_env, np);

--- a/tests/passthru/col_read.cpp
+++ b/tests/passthru/col_read.cpp
@@ -1,0 +1,201 @@
+/*
+ *    Copyright (C) 2022, Northwestern University and Argonne National Laboratory
+ *    See COPYRIGHT notice in top-level directory.
+ */
+#include <hdf5.h>
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "H5VL_log.h"
+#include "testutils.hpp"
+
+#define ASSERT_EQUAL(A, B)   \
+    {                        \
+        CHECK_ERR ((A - B)); \
+        CHECK_ERR ((B - A)); \
+    }
+
+int get_expected (int idx, int rank, int phase, int is_log, int np);
+
+int main (int argc, char **argv) {
+    herr_t err = 0;
+    int nerrs  = 0;
+    htri_t ret;
+    int i, ii;
+    int rank, np;
+    const char *file_name;
+    int mpi_required = 0;
+    int expected     = 0;
+
+    // VOL IDs
+    hid_t log_vlid = -1;
+
+    hid_t fid          = -1;  // File ID
+    hid_t did          = -1;  // Dataset ID
+    hid_t filespace_id = -1;  // File space ID
+    hid_t memspace_id  = -1;  // Memory space ID
+    hid_t faplid       = -1;  // File Access Property List
+    hid_t dxplid       = -1;  // Data transfer Property List
+
+    int *buf;
+    hsize_t dims[2] = {0, 0};  // dims[0] will be modified later
+    hsize_t start[2], count[2];
+    vol_env env;
+
+    // init MPI
+    MPI_Init_thread (&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
+    MPI_Comm_size (MPI_COMM_WORLD, &np);
+    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    buf = (int *)malloc (2 * np * sizeof (int));
+
+    if (argc > 2) {
+        if (!rank) printf ("Usage: %s [filename]\n", argv[0]);
+        MPI_Finalize ();
+        return 1;
+    } else if (argc > 1) {
+        file_name = argv[1];
+    } else {
+        file_name = "test.h5";
+    }
+
+    /* check VOL related environment variables */
+    check_env (&env);
+    SHOW_TEST_INFO ("Checking column read")
+
+    /* Set file access property list to MPI */
+    faplid = H5Pcreate (H5P_FILE_ACCESS);
+    CHECK_ERR (faplid);
+    err = H5Pset_fapl_mpio (faplid, MPI_COMM_WORLD, MPI_INFO_NULL);
+    CHECK_ERR (err);
+    err = H5Pset_all_coll_metadata_ops (faplid, 1);
+    CHECK_ERR (err);
+
+    /* Create file */
+    fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
+    CHECK_ERR (fid);
+
+    /* Create 2D (num_process x N) datasets */
+    dims[0]      = np;
+    dims[1]      = 2 * np;
+    filespace_id = H5Screate_simple (2, dims, dims);
+    CHECK_ERR (filespace_id);
+
+    did =
+        H5Dcreate2 (fid, "D", H5T_NATIVE_INT, filespace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    CHECK_ERR (did);
+
+    /* Prepare data */
+    for (i = 0; i < dims[1]; i++) { buf[i] = 100 * rank + i; }
+    start[0] = rank;
+    start[1] = 0;
+    count[0] = 1;
+    count[1] = dims[1];
+
+    /* File space setting */
+    err = H5Sselect_hyperslab (filespace_id, H5S_SELECT_SET, start, NULL, count, NULL);
+    CHECK_ERR (err);
+
+    /* Mem space setting */
+    memspace_id = H5Screate_simple (1, dims + 1, dims + 1);
+    CHECK_ERR (memspace_id);
+
+    /* Request to write data */
+    err = H5Dwrite (did, H5T_NATIVE_INT, memspace_id, filespace_id, H5P_DEFAULT, buf);
+    CHECK_ERR (err);
+    H5Fflush (fid, H5F_SCOPE_GLOBAL);
+    H5Sclose (memspace_id);
+
+    for (i = 0; i < dims[1]; i++) { buf[i] = -1; }
+
+    start[0] = 0;
+    start[1] = rank * 2;
+    count[0] = np;
+    count[1] = 1;
+
+    /* File space setting */
+    err = H5Sselect_hyperslab (filespace_id, H5S_SELECT_SET, start, NULL, count, NULL);
+    CHECK_ERR (err);
+
+    memspace_id = H5Screate_simple (1, dims, dims);
+    CHECK_ERR (memspace_id);
+
+    dxplid = H5Pcreate (H5P_DATASET_XFER);
+    err    = H5Pset_buffered (dxplid, true);
+    CHECK_ERR (err);
+
+    err = H5Dread (did, H5T_NATIVE_INT, memspace_id, filespace_id, dxplid, buf);
+    CHECK_ERR (err);
+
+    for (i = 0; i < dims[1]; i++) {
+        expected = get_expected (i, rank, 0, env.log_env, np);
+        ASSERT_EQUAL (buf[i], expected);
+    }
+
+    MPI_Barrier (MPI_COMM_WORLD);
+    start[0] = 0;
+    start[1] = rank * 2 + 1;
+    count[0] = np;
+    count[1] = 1;
+
+    /* File space setting */
+    err = H5Sselect_hyperslab (filespace_id, H5S_SELECT_SET, start, NULL, count, NULL);
+    CHECK_ERR (err);
+    err = H5Dread (did, H5T_NATIVE_INT, memspace_id, filespace_id, dxplid, buf + 4);
+
+    for (i = 0; i < dims[1]; i++) {
+        expected = get_expected (i, rank, 1, env.log_env, np);
+        ASSERT_EQUAL (buf[i], expected);
+    }
+
+    H5Fflush (fid, H5F_SCOPE_GLOBAL);
+
+    MPI_Barrier (MPI_COMM_WORLD);
+    for (i = 0; i < dims[1]; i++) {
+        expected = get_expected (i, rank, 2, env.log_env, np);
+        ASSERT_EQUAL (buf[i], expected);
+    }
+
+    /* Close everything */
+err_out:;
+    if (dxplid > 0) {
+        H5Pclose (dxplid);
+        dxplid = -1;
+    }
+    if (memspace_id >= 0) H5Sclose (memspace_id);
+    if (filespace_id >= 0) H5Sclose (filespace_id);
+    if (did >= 0) H5Dclose (did);
+    if (fid >= 0) H5Fclose (fid);
+    if (faplid >= 0) H5Pclose (faplid);
+    if (log_vlid >= 00) H5VLclose (log_vlid);
+    if (buf) free (buf);
+
+    MPI_Finalize ();
+
+    return (nerrs > 0);
+}
+
+int get_expected (int idx, int rank, int phase, int is_log, int np) {
+    int expected = -1;
+    int temp_idx = idx % np;
+    int region   = idx / np;
+    if (np == 1) region = idx;
+
+    if (phase == 0) {
+        if (is_log == 1) {
+            expected = -1;
+        } else if (region == 0) {
+            expected = temp_idx * 100 + 2 * rank + region;
+        }
+
+    } else if (phase == 1) {
+        if (is_log == 1) {
+            expected = -1;
+        } else {
+            expected = temp_idx * 100 + 2 * rank + region;
+        }
+    } else {
+        expected = temp_idx * 100 + 2 * rank + region;
+    }
+    return expected;
+}


### PR DESCRIPTION
This PR implements the pass-thru read feature for the Log VOL connector.

1. Currently, both blocking read and non-blocking read work.
2. To avoid the hyperslab order issue, read is performed per "contiguous block". This requires independent read mode.

Todo:
1. Clean codes.
2. (optional) Make one collective read per dataset, instead of many independent reads. This will be an optimization and will not change the correctness of the current implementation.
3. Add test cases to demonstrate the correctness the pass-thru read feature.
4. Mention the above in sneak_peak.