### PR TITLE
Fix Subfile Read Issue

### DIFF
--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -905,7 +905,8 @@ void H5VL_log_filei_open_subfile (H5VL_log_file_t *fp,
     err = H5Pset_fapl_mpio (fapl_id, fp->group_comm, MPI_INFO_NULL);
     CHECK_ERR
     H5VL_LOGI_PROFILING_TIMER_START;
-    fp->subname = fp->name + ".subfiles/" + fp->name + "." + std::to_string (fp->group_id);
+    fp->subname = fp->name + ".subfiles/" + std::string (basename ((char *)(fp->name.c_str ()))) +
+                  "." + std::to_string (fp->group_id);
     fp->sfp     = H5VLfile_open (fp->subname.c_str (), flags, fapl_id, dxpl_id, NULL);
     CHECK_PTR (fp->sfp)
     H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VLFILE_CREATE);

--- a/src/H5VL_logi_nb.cpp
+++ b/src/H5VL_logi_nb.cpp
@@ -554,40 +554,42 @@ void H5VL_log_nb_flush_read_reqs (void *file, std::vector<H5VL_log_rreq_t *> &re
         (fp->config & H5VL_FILEI_CONFIG_SINGLE_SUBFILE_READ)) {
         H5VL_log_nb_perform_read (fp, reqs, dxplid);
     } else {
-        group_id = fp->group_id;  // Backup group ID
-        // Process our own subfile last so wew don't need to reopen it
-        for (i = 1; i <= fp->ngroup; i++) {
-            H5VL_LOGI_PROFILING_TIMER_START;
-            // Close the log group
-            err = H5VLgroup_close (fp->lgp, fp->uvlid, fp->dxplid, NULL);
-            CHECK_ERR
-            // Close previous subfile with MPI
-            mpierr = MPI_File_close (&(fp->fh));
-            CHECK_MPIERR
-            // Close previous subfile
-            err = H5VLfile_close (fp->sfp, fp->uvlid, H5P_DATASET_XFER_DEFAULT, NULL);
-            CHECK_ERR
-            // Erase the index table of previous subfile
-            fp->idx->clear ();
-            fp->idxvalid = false;
+        // TODO: Fix subfile read
 
-            // Open the current subfile
-            fp->group_id = (group_id + i) % fp->ngroup;
-            H5VL_log_filei_open_subfile (fp, fp->flag, fp->ufaplid, fp->dxplid);
+        // group_id = fp->group_id;  // Backup group ID
+        // // Process our own subfile last so wew don't need to reopen it
+        // for (i = 1; i <= fp->ngroup; i++) {
+        //     H5VL_LOGI_PROFILING_TIMER_START;
+        //     // Close the log group
+        //     err = H5VLgroup_close (fp->lgp, fp->uvlid, fp->dxplid, NULL);
+        //     CHECK_ERR
+        //     // Close previous subfile with MPI
+        //     mpierr = MPI_File_close (&(fp->fh));
+        //     CHECK_MPIERR
+        //     // Close previous subfile
+        //     err = H5VLfile_close (fp->sfp, fp->uvlid, H5P_DATASET_XFER_DEFAULT, NULL);
+        //     CHECK_ERR
+        //     // Erase the index table of previous subfile
+        //     fp->idx->clear ();
+        //     fp->idxvalid = false;
 
-            // Open the LOG group
-            loc.obj_type = H5I_FILE;
-            loc.type     = H5VL_OBJECT_BY_SELF;
-            fp->lgp      = H5VLgroup_open (fp->sfp, &loc, fp->uvlid, H5VL_LOG_FILEI_GROUP_LOG,
-                                      H5P_GROUP_ACCESS_DEFAULT, fp->dxplid, NULL);
-            CHECK_PTR (fp->lgp)
-            // Open the file with MPI
-            mpierr = MPI_File_open (fp->group_comm, fp->subname.c_str (), MPI_MODE_RDWR, fp->info,
-                                    &(fp->fh));
-            CHECK_MPIERR
+        //     // Open the current subfile
+        //     fp->group_id = (group_id + i) % fp->ngroup;
+        //     H5VL_log_filei_open_subfile (fp, fp->flag, fp->ufaplid, fp->dxplid);
 
-            H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VL_LOG_NB_FLUSH_READ_REQS_SWITCH_SUBFILE);
-        }
+        //     // Open the LOG group
+        //     loc.obj_type = H5I_FILE;
+        //     loc.type     = H5VL_OBJECT_BY_SELF;
+        //     fp->lgp      = H5VLgroup_open (fp->sfp, &loc, fp->uvlid, H5VL_LOG_FILEI_GROUP_LOG,
+        //                               H5P_GROUP_ACCESS_DEFAULT, fp->dxplid, NULL);
+        //     CHECK_PTR (fp->lgp)
+        //     // Open the file with MPI
+        //     mpierr = MPI_File_open (fp->group_comm, fp->subname.c_str (), MPI_MODE_RDWR, fp->info,
+        //                             &(fp->fh));
+        //     CHECK_MPIERR
+
+        //     H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VL_LOG_NB_FLUSH_READ_REQS_SWITCH_SUBFILE);
+        // }
     }
 
     // Clear the request queue


### PR DESCRIPTION
Currently several issues exist in subfile read feature.


Running the following E3SM-IO benchmark using commit newer than e3aef7c will result in several errors:

```shell
# e3sm-io commands, this enables subfile feature
./e3sm_io -g 1 -k -a hdf5_log -x log -o ./test_output/hdf5_log_log_map_i_case_16p.h5 path-to-datasets/map_i_case_16p.h5
```

1. Using HDF5 1.14.0 build-mode=production:
    1. [H5VLfile_close](https://github.com/DataLib-ECP/vol-log-based/blob/68ffd85accfce126d48beca97c7130541d355202/src/H5VL_logi_nb.cpp#L568) will trigger an error, where an `H5CX_xx` call complains about invalid IDs. This issue is related to `H5VL_logi_reset_lib_stat` calls. Adding only one (pair of) `H5VL_logi_reset_lib_stat` around [`H5VL_log_filei_flush`](https://github.com/DataLib-ECP/vol-log-based/blob/68ffd85accfce126d48beca97c7130541d355202/src/H5VL_log_file.cpp#L450) is not enough. We need to add two (pairs) [inside `H5VL_log_filei_flush`](https://github.com/DataLib-ECP/vol-log-based/blob/68ffd85accfce126d48beca97c7130541d355202/src/H5VL_log_filei.cpp#L657), one for `H5VL_log_nb_flush_write_reqs` and one for `H5VL_log_nb_flush_read_reqs`
    2. After fixing the above issue, another error inside [`H5VL_log_filei_open_subfile`](https://github.com/DataLib-ECP/vol-log-based/blob/68ffd85accfce126d48beca97c7130541d355202/src/H5VL_logi_nb.cpp#L576) will occur. This error complains about an invalid VOL id, which should also be related to lib_stat calls.
    3. The subfile name used in [`H5VL_log_filei_open_subfile`](https://github.com/DataLib-ECP/vol-log-based/blob/68ffd85accfce126d48beca97c7130541d355202/src/H5VL_log_filei.cpp#L908) is not correct. This issue is fixed.
    4. Using Log VOL release 1.4.0 will not cause any issues. This is because each process only perform read/write flush requests if the requests size > 0. The above e3sm-io command results in the read-requests-size=0 so no read logic is performed and no error is triggered. After commit e3aef7c, we no more check "requests size > 0".
2. Using HDF5 1.14.0 build-mode=debug:
    1. An assertion error will occur inside [`H5VL_log_filei_create_subfile`](https://github.com/DataLib-ECP/vol-log-based/blob/68ffd85accfce126d48beca97c7130541d355202/src/H5VL_log_filei.cpp#L249).  HDFGroup/hdf5#2220 should be a similar issue. We already followed their advice to move everything to the post open callback but is still having the issue.

Currently the subfile read feature is disabled and using HDF5 1.14.0 production mode should not give errors.


