### PR TITLE
Fix Possible Out of Memory Issue when Read

### DIFF
--- a/src/H5VL_log_dataseti.cpp
+++ b/src/H5VL_log_dataseti.cpp
@@ -1121,6 +1121,7 @@ void H5VL_log_dataseti_read (H5VL_log_dset_t *dp,
     // Flush it immediately if blocking, otherwise place into queue
     if (rtype != true) {
         num_pending_writes = H5VL_log_filei_get_num_pending_writes (dp->fp);
+        MPI_Allreduce(MPI_IN_PLACE, &num_pending_writes, 1, MPI_UNSIGNED_LONG, MPI_MAX, dp->fp->comm);
         if (num_pending_writes > 0) {
             H5VL_log_nb_flush_write_reqs (dp->fp);
         }

--- a/src/H5VL_log_dataseti.cpp
+++ b/src/H5VL_log_dataseti.cpp
@@ -1122,11 +1122,10 @@ void H5VL_log_dataseti_read (H5VL_log_dset_t *dp,
     if (rtype != true) {
         num_pending_writes = H5VL_log_filei_get_num_pending_writes (dp->fp);
         if (num_pending_writes > 0) {
-            ERR_OUT ("cannot read data when there are pending write requests.");
-        } else {
-            std::vector<H5VL_log_rreq_t *> tmp (1, r);
-            H5VL_log_nb_flush_read_reqs (dp->fp, tmp, plist_id);
+            H5VL_log_nb_flush_write_reqs (dp->fp);
         }
+        std::vector<H5VL_log_rreq_t *> tmp (1, r);
+        H5VL_log_nb_flush_read_reqs (dp->fp, tmp, plist_id);
     } else {
         dp->fp->rreqs.push_back (r);
     }

--- a/src/H5VL_log_dataseti.cpp
+++ b/src/H5VL_log_dataseti.cpp
@@ -1046,6 +1046,7 @@ void H5VL_log_dataseti_read (H5VL_log_dset_t *dp,
     hbool_t rtype;        // Non-blocking?
     size_t num_pending_writes = 0;
     void *lib_state = NULL;
+    H5FD_mpio_xfer_t xfer_mode;
     H5VL_logi_err_finally finally (
         [&lib_state] () -> void { H5VL_logi_restore_lib_stat (lib_state); });
     H5VL_LOGI_PROFILING_TIMER_START;
@@ -1120,11 +1121,16 @@ void H5VL_log_dataseti_read (H5VL_log_dset_t *dp,
 
     // Flush it immediately if blocking, otherwise place into queue
     if (rtype != true) {
-        num_pending_writes = H5VL_log_filei_get_num_pending_writes (dp->fp);
-        MPI_Allreduce(MPI_IN_PLACE, &num_pending_writes, 1, MPI_UNSIGNED_LONG, MPI_MAX, dp->fp->comm);
-        if (num_pending_writes > 0) {
-            H5VL_log_nb_flush_write_reqs (dp->fp);
+        // flush pending write requests if collective
+        err = H5Pget_dxpl_mpio (dp->fp->dxplid, &xfer_mode);
+        CHECK_ERR
+        if ((xfer_mode == H5FD_MPIO_COLLECTIVE) || dp->fp->np == 1) {
+            num_pending_writes = H5VL_log_filei_get_num_pending_writes (dp->fp);
+            MPI_Allreduce (MPI_IN_PLACE, &num_pending_writes, 1, MPI_UNSIGNED_LONG, MPI_MAX,
+                           dp->fp->comm);
+            if (num_pending_writes > 0) { H5VL_log_nb_flush_write_reqs (dp->fp); }
         }
+
         std::vector<H5VL_log_rreq_t *> tmp (1, r);
         H5VL_log_nb_flush_read_reqs (dp->fp, tmp, plist_id);
     } else {

--- a/src/H5VL_log_file.hpp
+++ b/src/H5VL_log_file.hpp
@@ -108,7 +108,7 @@ typedef struct H5VL_log_file_t : H5VL_log_obj_t {
     // std::vector<int> lut;
     H5VL_logi_idx_t *idx;  // Index of data, for reading
     bool idxvalid;         // Is index up to date
-    bool metadirty;        // Is there pending metadata to flush
+    bool metadirty;        // Is there pending metadata to 
 
     // Configuration flag
     int config;  // Config flags

--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -654,11 +654,38 @@ void H5VL_log_filei_contig_buffer_alloc (H5VL_log_buffer_pool_t *p) {
     p->inf   = 0;
 }
 
+size_t H5VL_log_filei_get_num_pending_writes(H5VL_log_file_t *fp) {
+    size_t num, i;
+
+    num = fp->wreqs.size () - fp->nflushed;
+    for (i = 0; i < fp->mreqs.size (); i++) {
+        if (fp->mreqs[i] && (fp->mreqs[i]->nsel > 0)) {
+            num++;
+        }
+    }
+    return num;
+}
+
 void H5VL_log_filei_flush (H5VL_log_file_t *fp, hid_t dxplid) {
     H5VL_LOGI_PROFILING_TIMER_START;
+    size_t num_reqs[2] = {0};
+    int i;
 
-    H5VL_log_nb_flush_write_reqs (fp);
-    H5VL_log_nb_flush_read_reqs (fp, fp->rreqs, dxplid);
+    num_reqs[0] = H5VL_log_filei_get_num_pending_writes(fp);  // num of write requests
+    num_reqs[1] = fp->rreqs.size ();  // num of read requests
+
+    MPI_Allreduce(MPI_IN_PLACE, num_reqs, 2, MPI_UNSIGNED_LONG, MPI_MAX, fp->comm);
+    if (num_reqs[0] > 0 && num_reqs[1] > 0) {
+        ERR_OUT ("cannot read data when there are pending write requests.");
+    }
+
+    if (num_reqs[0] > 0) {
+        H5VL_log_nb_flush_write_reqs (fp);
+    }
+
+    if (num_reqs[1] > 0) {
+        H5VL_log_nb_flush_read_reqs (fp, fp->rreqs, dxplid);
+    }
 
     H5VL_LOGI_PROFILING_TIMER_STOP (fp, TIMER_H5VL_LOG_FILEI_FLUSH);
 }

--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -397,7 +397,7 @@ void H5VL_log_filei_parse_fapl (H5VL_log_file_t *fp, hid_t faplid) {
     CHECK_ERR
     if (encoding == H5VL_LOG_ENCODING_OFFSET) { fp->config |= H5VL_FILEI_CONFIG_SEL_ENCODE; }
     */
-    fp->index_type = list;
+    fp->index_type = compact;
     env            = getenv ("H5VL_LOG_INDEX_TYPE");
     if (env) {
         if (strcmp (env, "compact") == 0) {

--- a/src/H5VL_log_filei.cpp
+++ b/src/H5VL_log_filei.cpp
@@ -675,9 +675,6 @@ void H5VL_log_filei_flush (H5VL_log_file_t *fp, hid_t dxplid) {
     num_reqs[1] = fp->rreqs.size ();  // num of read requests
 
     MPI_Allreduce(MPI_IN_PLACE, num_reqs, 2, MPI_UNSIGNED_LONG, MPI_MAX, fp->comm);
-    if (num_reqs[0] > 0 && num_reqs[1] > 0) {
-        ERR_OUT ("cannot read data when there are pending write requests.");
-    }
 
     if (num_reqs[0] > 0) {
         H5VL_log_nb_flush_write_reqs (fp);

--- a/src/H5VL_log_filei.hpp
+++ b/src/H5VL_log_filei.hpp
@@ -49,6 +49,7 @@ extern herr_t H5VL_log_filei_dset_visit (hid_t o_id,
                                          const char *name,
                                          const H5O_info_t *object_info,
                                          void *op_data);
+extern size_t H5VL_log_filei_get_num_pending_writes(H5VL_log_file_t *fp);
 extern void H5VL_log_filei_flush (H5VL_log_file_t *fp, hid_t dxplid);
 extern void H5VL_log_filei_metaflush (H5VL_log_file_t *fp);
 extern void H5VL_log_filei_metaupdate (H5VL_log_file_t *fp);

--- a/src/H5VL_log_filei_meta.cpp
+++ b/src/H5VL_log_filei_meta.cpp
@@ -456,8 +456,10 @@ void H5VL_log_filei_metaupdate_part (H5VL_log_file_t *fp, int &md, int &sec) {
     fp->idx->clear ();
 
     // Open the metadata dataset
+    loc.type     = H5VL_OBJECT_BY_SELF;
+    loc.obj_type = H5I_GROUP;
     sprintf (mdname, "%s_%d", H5VL_LOG_FILEI_DSET_META, md);
-    mdp = H5VLdataset_open (fp->lgp, &loc, fp->uvlid, "_idx", H5P_DATASET_ACCESS_DEFAULT,
+    mdp = H5VLdataset_open (fp->lgp, &loc, fp->uvlid, mdname, H5P_DATASET_ACCESS_DEFAULT,
                             fp->dxplid, NULL);
     CHECK_PTR (mdp)
 
@@ -508,7 +510,7 @@ void H5VL_log_filei_metaupdate_part (H5VL_log_file_t *fp, int &md, int &sec) {
         sec = 0;
         md++;
     }
-    if (md > fp->nmdset) { md = -1; }
+    if (md >= fp->nmdset) { md = -1; }
 
     // Allocate buffer for raw metadata
     buf = (char *)malloc (sizeof (char) * count);

--- a/src/H5VL_logi_nb.cpp
+++ b/src/H5VL_logi_nb.cpp
@@ -304,7 +304,7 @@ void H5VL_log_merged_wreq_t::append (H5VL_log_dset_t *dp,
     *((int *)(this->sel_buf)) = nsel;
 
     // Append data
-    this->dbufs.push_back ({db.xbuf, db.ubuf, db.size});
+    this->dbufs.push_back ({db.ubuf, db.xbuf, db.size});
     this->hdr->fsize += db.size;
 
     // Update metadata size
@@ -528,13 +528,6 @@ void H5VL_log_nb_flush_read_reqs (void *file, std::vector<H5VL_log_rreq_t *> &re
     H5VL_loc_params_t loc;
     H5VL_log_file_t *fp = (H5VL_log_file_t *)file;
     H5VL_log_dset_info_t *dip;
-
-    // Collective ?
-    err = H5Pget_dxpl_mpio (dxplid, &xfer_mode);
-    CHECK_ERR
-    if ((xfer_mode == H5FD_MPIO_COLLECTIVE) || fp->np == 1) {
-        H5VL_log_nb_flush_write_reqs (fp);
-    }
 
     H5VL_LOGI_PROFILING_TIMER_START;
 

--- a/src/H5VL_logi_nb.hpp
+++ b/src/H5VL_logi_nb.hpp
@@ -45,7 +45,7 @@ class H5VL_log_wreq_t {
     MPI_Offset
         meta_off;  // Offset of the metadata related to the starting metadata block of the process
 
-    std::vector<H5VL_log_req_data_block_t> dbufs;  // Data buffers <xbuf, ubuf, size>
+    std::vector<H5VL_log_req_data_block_t> dbufs;  // Data buffers <ubuf, xbuf, size>
 
     size_t operator() () const;
     bool operator== (H5VL_log_wreq_t &rhs) const;


### PR DESCRIPTION
In the current implementation, calling H5Fflush will try to flush both pending write requests and pending read requests. When trying to flush a pending read request, Log VOL will always update the `index` ( a structure maintained by Log VOL for dataset read operation). Updating the `index` may cause an Out of Memory (OOM) issue if the log format file contains a lot of write requests / blocks, and if using a large number of MPI processes. The OOM issue could be reproduced using the E3SM-IO benchmark using 16p f-case on a single node machine with 16G memory.

This PR fixes the above issue:

1. when calling flush, `MPI_ALLREDUCE` is first called to get the maximum number of pending write/read requests. Perform write/read logic only if the number got from `MPI_ALLREDUCE` > 0.
2. change the default `index` type from array_index to compact_index. The difference between the two is how they handle the selection reference. i.e. If two write records to be read share the same selection space, using array_index will save the selection space twice, while using compact_index only saves once.
3. Fix bugs related to  compact_index