### PR TITLE
Stand-alone tests without Log VOL

### DIFF
--- a/.github/workflows/alone.yml
+++ b/.github/workflows/alone.yml
@@ -24,7 +24,7 @@ env:
    MPICH_VERSION: 4.1.2
    HDF5_VERSION: 1.14.2
    ARGOBOTS_VERSION: 1.1
-   ASYNC_VOL_VERSION: 1.8
+   ASYNC_VOL_VERSION: 1.8.1
 
 jobs:
     build:

--- a/.github/workflows/alone.yml
+++ b/.github/workflows/alone.yml
@@ -1,0 +1,208 @@
+name: Tests VOLs implicitly
+
+on:
+  push:
+    branches: [ master, dev ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.jpg'
+      - '**/*.png'
+      - 'docs/*'
+      - 'case_studies/*'
+  pull_request:
+    branches: [ master, dev ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.jpg'
+      - '**/*.png'
+      - 'docs/*'
+      - 'case_studies/*'
+
+env:
+   MPICH_VERSION: 4.1.2
+   HDF5_VERSION: 1.14.2
+   ARGOBOTS_VERSION: 1.1
+   ASYNC_VOL_VERSION: 1.8
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      steps:
+        - uses: actions/checkout@v3
+        - name: Set up dependencies
+          run: |
+            sudo apt-get update
+            sudo apt-get -y install automake autoconf libtool libtool-bin m4 cmake
+            # The MPICH installed on github actions is too slow
+            # sudo apt-get install mpich
+            # mpicc -v
+            # zlib
+            sudo apt-get -y install zlib1g-dev
+        - name: Build MPICH
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            rm -rf ${GITHUB_WORKSPACE}/MPICH
+            mkdir ${GITHUB_WORKSPACE}/MPICH
+            cd ${GITHUB_WORKSPACE}/MPICH
+            wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+            gzip -dc mpich-${MPICH_VERSION}.tar.gz | tar -xf -
+            cd mpich-${MPICH_VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/MPICH \
+                        --silent \
+                        --enable-romio \
+                        --with-file-system=ufs \
+                        --with-device=ch3:sock \
+                        --disable-fortran \
+                        CC=gcc
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+            make -s -j 8 distclean >> qout 2>&1
+        - name: Install HDF5
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            rm -rf ${GITHUB_WORKSPACE}/HDF5
+            mkdir ${GITHUB_WORKSPACE}/HDF5
+            cd ${GITHUB_WORKSPACE}/HDF5
+            VER_MAJOR=${HDF5_VERSION%.*}
+            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${VER_MAJOR}/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
+            tar -zxf hdf5-${HDF5_VERSION}.tar.gz
+            cd hdf5-${HDF5_VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/HDF5 \
+                        --silent \
+                        --enable-parallel \
+                        --enable-build-mode=production \
+                        --enable-unsupported \
+                        --enable-threadsafe \
+                        --disable-doxygen-doc \
+                        --disable-doxygen-man \
+                        --disable-doxygen-html \
+                        --disable-tests \
+                        --disable-fortran \
+                        --disable-cxx \
+                        CC=${GITHUB_WORKSPACE}/MPICH/bin/mpicc
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+            make -s -j 8 distclean >> qout 2>&1
+        - name: Install Argobots
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            ABT_DIR=${GITHUB_WORKSPACE}/Argobots
+            rm -rf ${ABT_DIR}
+            mkdir ${ABT_DIR}
+            cd ${ABT_DIR}
+            wget -qc https://github.com/pmodels/argobots/archive/refs/tags/v${ARGOBOTS_VERSION}.tar.gz
+            tar -xf v${ARGOBOTS_VERSION}.tar.gz
+            cd argobots-${ARGOBOTS_VERSION}
+            ./autogen.sh
+            ./configure --prefix=${ABT_DIR} \
+                        --silent \
+                        CC=${GITHUB_WORKSPACE}/MPICH/bin/mpicc \
+                        CXX=${GITHUB_WORKSPACE}/MPICH/bin/mpicxx
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+            make -s -j 8 distclean >> qout 2>&1
+        - name: Install Async VOL
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            export ABT_DIR=${GITHUB_WORKSPACE}/Argobots
+            export HDF5_DIR=${GITHUB_WORKSPACE}/HDF5
+            export ASYNC_DIR=${GITHUB_WORKSPACE}/Async
+            export HDF5_ROOT=${HDF5_DIR}
+            rm -rf ${ASYNC_DIR}
+            mkdir ${ASYNC_DIR}
+            cd ${ASYNC_DIR}
+            wget -qc https://github.com/hpc-io/vol-async/archive/refs/tags/v${ASYNC_VOL_VERSION}.tar.gz
+            tar -xf v${ASYNC_VOL_VERSION}.tar.gz
+            cd vol-async-${ASYNC_VOL_VERSION}
+            mkdir build
+            cd build
+            CC=${GITHUB_WORKSPACE}/MPICH/bin/mpicc \
+              CXX=${GITHUB_WORKSPACE}/MPICH/bin/mpicxx \
+              cmake .. -DCMAKE_INSTALL_PREFIX=${ASYNC_DIR}
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+        - name: Install Cache VOL
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            export ABT_DIR=${GITHUB_WORKSPACE}/Argobots
+            export HDF5_DIR=${GITHUB_WORKSPACE}/HDF5
+            export ASYNC_DIR=${GITHUB_WORKSPACE}/Async
+            export CAHCE_DIR=${GITHUB_WORKSPACE}/Cache
+            export HDF5_ROOT=${HDF5_DIR}
+            rm -rf ${CAHCE_DIR}
+            mkdir ${CAHCE_DIR}
+            cd ${CAHCE_DIR}
+            git clone https://github.com/hpc-io/vol-cache.git
+            cd vol-cache
+            mkdir build
+            cd build
+            export LD_LIBRARY_PATH="$ABT_DIR/lib:$LD_LIBRARY_PATH"
+            CC=${GITHUB_WORKSPACE}/MPICH/bin/mpicc \
+              CXX=${GITHUB_WORKSPACE}/MPICH/bin/mpicxx \
+              CFLAGS=-DNDEBUG \
+              HDF5_VOL_DIR=${ASYNC_DIR} \
+              cmake .. -DCMAKE_INSTALL_PREFIX=${CAHCE_DIR}
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+        - name: build test program in folder tests/basic
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}/tests/basic
+            export HDF5_DIR=${GITHUB_WORKSPACE}/HDF5
+            export LD_LIBRARY_PATH=${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+            make -f makefile.alone V=1 \
+                    MPICXX=${GITHUB_WORKSPACE}/MPICH/bin/mpicxx
+        - name: run test program in folder tests/basic, HDF5 only
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}/tests/basic
+            export HDF5_DIR=${GITHUB_WORKSPACE}/HDF5
+            export LD_LIBRARY_PATH=${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+            make -f makefile.alone V=1 \
+                    MPIEXEC=${GITHUB_WORKSPACE}/MPICH/bin/mpiexec \
+                    ptest
+        - name: Test Cache VOL only
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}/tests/basic
+            export ABT_DIR=${GITHUB_WORKSPACE}/Argobots
+            export ASYNC_DIR=${GITHUB_WORKSPACE}/Async
+            export CACHE_DIR=${GITHUB_WORKSPACE}/Cache
+            export HDF5_DIR=${GITHUB_WORKSPACE}/HDF5
+            export HDF5_ROOT=${HDF5_DIR}
+            export LD_LIBRARY_PATH=${CACHE_DIR}/lib:${ASYNC_DIR}/lib:${ABT_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+            export HDF5_PLUGIN_PATH=${CACHE_DIR}/lib
+            export HDF5_VOL_CONNECTOR="cache_ext config=${GITHUB_WORKSPACE}/tests/basic/cache.cfg;under_vol=0;under_info={}"
+            export MPICH_MAX_THREAD_SAFETY=multiple
+            export HDF5_USE_FILE_LOCKING=FALSE
+            export HDF5_ASYNC_DISABLE_DSET_GET=0
+            make -f makefile.alone V=1 \
+                    MPIEXEC=${GITHUB_WORKSPACE}/MPICH/bin/mpiexec \
+                    ptest
+        - name: Test Async and Cache VOLs
+          if: ${{ success() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}/tests/basic
+            export ABT_DIR=${GITHUB_WORKSPACE}/Argobots
+            export ASYNC_DIR=${GITHUB_WORKSPACE}/Async
+            export CACHE_DIR=${GITHUB_WORKSPACE}/Cache
+            export HDF5_DIR=${GITHUB_WORKSPACE}/HDF5
+            export HDF5_ROOT=${HDF5_DIR}
+            export HDF5_PLUGIN_PATH=${CACHE_DIR}/lib:${ASYNC_DIR}/lib
+            export LD_LIBRARY_PATH=${CACHE_DIR}/lib:${ASYNC_DIR}/lib:${ABT_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+            export HDF5_VOL_CONNECTOR="cache_ext config=${GITHUB_WORKSPACE}/tests/basic/cache.cfg;under_vol=512;under_info={under_vol=0;under_info={}}"
+            export MPICH_MAX_THREAD_SAFETY=multiple
+            export HDF5_USE_FILE_LOCKING=FALSE
+            export HDF5_ASYNC_DISABLE_DSET_GET=0
+            make -f makefile.alone V=1 \
+                    MPIEXEC=${GITHUB_WORKSPACE}/MPICH/bin/mpiexec \
+                    ptest
+        - name: make clean
+          if: ${{ always() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}/tests/basic
+            make -f makefile.alone clean
+

--- a/.github/workflows/ubuntu_stack_vols.yml
+++ b/.github/workflows/ubuntu_stack_vols.yml
@@ -24,7 +24,7 @@ env:
    MPICH_VERSION: 4.1.2
    HDF5_VERSION: 1.14.2
    ARGOBOTS_VERSION: 1.1
-   ASYNC_VOL_VERSION: 1.8
+   ASYNC_VOL_VERSION: 1.8.1
 
 jobs:
     build:

--- a/tests/basic/Makefile.am
+++ b/tests/basic/Makefile.am
@@ -16,6 +16,7 @@ AM_CPPFLAGS += -I${top_srcdir}/src
 AM_CPPFLAGS += -I${top_srcdir}/tests
 AM_CPPFLAGS += -I${top_builddir}
 AM_CPPFLAGS += -I${top_builddir}/src
+AM_CPPFLAGS += -DTEST_H5VL_LOG
 
 LDADD = $(top_builddir)/src/libH5VL_log.la ../common/libtestutils.la
 

--- a/tests/basic/common.hpp
+++ b/tests/basic/common.hpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2022, Northwestern University and Argonne National Laboratory
+ *  See COPYRIGHT notice in top-level directory.
+ */
+
+#pragma once
+#include <stdio.h>
+#include <hdf5.h>
+#include <libgen.h>
+#include <mpi.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#define CHECK_ERR(A) {                                                    \
+    if (A < 0) {                                                          \
+        nerrs++;                                                          \
+        printf ("Error at line %d in %s:\n", __LINE__, __FILE__);         \
+        goto err_out;                                                     \
+    }                                                                     \
+}
+
+#define CHECK_ID(A) {                                                     \
+    if (A < 0) {                                                          \
+        nerrs++;                                                          \
+        printf ("Error at line %d in %s: HDF5 object %s ID is invalid\n", \
+                __LINE__, __FILE__, #A);                                  \
+        H5Eprint1 (stdout);                                               \
+        goto err_out;                                                     \
+    }                                                                     \
+}
+
+#define EXP_ERR(A, B) {                                                   \
+    if (A != B) {                                                         \
+        nerrs++;                                                          \
+        printf("Error at line %d in %s: expecting %ld but got %d\n",      \
+               __LINE__, __FILE__, A, B);                                 \
+        goto err_out;                                                     \
+    }                                                                     \
+}
+
+#define EXP_VAL(A, B) {                                                   \
+    if (A != B) {                                                         \
+        nerrs++;                                                          \
+        std::cout << "Error at line " << __LINE__ << " in " << __FILE__   \
+                  << ": expecting " << #A << " = " << (B) << ", but got " \
+                  << (A) << std::endl;                                    \
+        goto err_out;                                                     \
+    }                                                                     \
+}
+
+#define EXP_VAL_EX(A, B, C) {                                             \
+    if (A != B) {                                                         \
+        nerrs++;                                                          \
+        std::cout << "Error at line " << __LINE__ << " in " << __FILE__   \
+                  << ": expecting " << C << " = " << (B) << ", but got "  \
+                  << (A) << std::endl;                                    \
+        goto err_out;                                                     \
+    }                                                                     \
+}
+
+#define SHOW_TEST_INFO(A) {                                                \
+    if (rank == 0) printf("  * TESTING CXX    %-48s ---- ", A);            \
+}
+
+#define SHOW_TEST_RESULT {                                                    \
+    MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD); \
+    if (rank == 0) {                                                          \
+        if (nerrs)                                                            \
+            std::cout << "fail with " << nerrs << " mismatches." << std::endl;\
+        else                                                                  \
+            std::cout << "pass" << std::endl;                                 \
+    }                                                                         \
+}
+
+#define PASS_STR "pass\n"
+#define SKIP_STR "skip\n"
+#define FAIL_STR "fail with %d mismatches\n"
+
+#define HDfprintf    printf
+#define HDfree       free
+#define failure_mssg "Fail"
+#define FUNC         "func"
+#define FALSE        0
+#define TRUE         1
+

--- a/tests/basic/dread.cpp
+++ b/tests/basic/dread.cpp
@@ -8,8 +8,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 int main (int argc, char **argv) {
     herr_t err = 0;
@@ -22,11 +26,9 @@ int main (int argc, char **argv) {
     hid_t sid      = -1;  // Dataset space ID
     hid_t msid     = -1;  // Memory space ID
     hid_t faplid   = -1;
-    hid_t log_vlid = H5I_INVALID_HID;  // Logvol ID
     hsize_t dims[2];
     hsize_t start[2], count[2];
     int *buf = NULL;
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -44,10 +46,6 @@ int main (int argc, char **argv) {
         file_name = "dread.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Blocking read")
-
     faplid = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (faplid)
     // MPI and collective metadata is required by LOG VOL
@@ -56,13 +54,22 @@ int main (int argc, char **argv) {
     err = H5Pset_all_coll_metadata_ops (faplid, 1);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Blocking read")
 
     // Create file
     fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -129,7 +136,6 @@ err_out:
     if (did >= 0) H5Dclose (did);
     if (fid >= 0) H5Fclose (fid);
     if (faplid >= 0) H5Pclose (faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/dset.cpp
+++ b/tests/basic/dset.cpp
@@ -8,8 +8,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define N 10
 #define M 10
@@ -26,10 +30,8 @@ int main (int argc, char **argv) {
     hid_t sid       = -1;  // Dataset space ID
     hid_t msid      = -1;  // Memory space ID
     hid_t faplid    = -1;
-    hid_t log_vlid  = H5I_INVALID_HID;  // Logvol ID
     hsize_t dims[2] = {N, M};
     hsize_t mdims[2];
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -47,10 +49,6 @@ int main (int argc, char **argv) {
         file_name = "dset.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Creating datasets")
-
     faplid = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (faplid)
     // MPI and collective metadata is required by LOG VOL
@@ -59,13 +57,22 @@ int main (int argc, char **argv) {
     err = H5Pset_all_coll_metadata_ops (faplid, 1);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Creating datasets")
 
     // Create file
     fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -137,7 +144,6 @@ err_out:
     if (gid >= 0) H5Gclose (gid);
     if (fid >= 0) H5Fclose (fid);
     if (faplid >= 0) H5Pclose (faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/dwrite.cpp
+++ b/tests/basic/dwrite.cpp
@@ -8,8 +8,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define N 10
 
@@ -24,11 +28,9 @@ int main (int argc, char **argv) {
     hid_t sid       = -1;  // Dataset space ID
     hid_t msid      = -1;  // Memory space ID
     hid_t faplid    = -1;
-    hid_t log_vlid  = H5I_INVALID_HID;  // Logvol ID
     hsize_t dims[2] = {0, N};
     hsize_t start[2], count[2];
     int buf[N];
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -46,10 +48,6 @@ int main (int argc, char **argv) {
         file_name = "dwrite.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Blocking write")
-
     faplid = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (faplid)
     // MPI and collective metadata is required by LOG VOL
@@ -58,13 +56,22 @@ int main (int argc, char **argv) {
     err = H5Pset_all_coll_metadata_ops (faplid, 1);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Blocking write")
 
     // Create file
     fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -110,7 +117,6 @@ err_out:;
     if (did >= 0) H5Dclose (did);
     if (fid >= 0) H5Fclose (fid);
     if (faplid >= 0) H5Pclose (faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/file.cpp
+++ b/tests/basic/file.cpp
@@ -8,8 +8,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define N 10
 
@@ -19,8 +23,6 @@ int main (int argc, char **argv) {
     const char *file_name;
     hid_t fid      = -1;  // File ID
     hid_t faplid   = -1;
-    hid_t log_vlid = H5I_INVALID_HID;  // Logvol ID
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -38,10 +40,6 @@ int main (int argc, char **argv) {
         file_name = "file.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Creating files")
-
     faplid = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (faplid)
     // MPI and collective metadata is required by LOG VOL
@@ -50,13 +48,22 @@ int main (int argc, char **argv) {
     err = H5Pset_all_coll_metadata_ops (faplid, 1);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Creating files")
 
     // Create file
     fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -75,7 +82,6 @@ int main (int argc, char **argv) {
 err_out:
     if (fid >= 0) H5Fclose (fid);
     if (faplid >= 0) H5Pclose (faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/fill.cpp
+++ b/tests/basic/fill.cpp
@@ -9,8 +9,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define FILL_VAL 123456789
 
@@ -26,11 +30,9 @@ int main (int argc, char **argv) {
     hid_t msid     = -1;  // Memory space ID
     hid_t faplid   = -1;
     hid_t dcplid   = -1;  // Dataset creation property;
-    hid_t log_vlid = H5I_INVALID_HID;  // Logvol ID
     hsize_t dims[2];
     hsize_t start[2], count[2];
     int *buf = NULL;
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -48,10 +50,6 @@ int main (int argc, char **argv) {
         file_name = "fill.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Blocking read")
-
     faplid = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (faplid)
     // MPI and collective metadata is required by LOG VOL
@@ -60,13 +58,22 @@ int main (int argc, char **argv) {
     err = H5Pset_all_coll_metadata_ops (faplid, 1);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Fill mode")
 
     // Create file
     fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -177,7 +184,6 @@ err_out:
     if (did >= 0) H5Dclose (did);
     if (fid >= 0) H5Fclose (fid);
     if (faplid >= 0) H5Pclose (faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/group.cpp
+++ b/tests/basic/group.cpp
@@ -8,8 +8,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define N 10
 
@@ -21,8 +25,6 @@ int main (int argc, char **argv) {
     hid_t gid      = -1;  // Group ID
     hid_t sgid     = -1;  // Subgroup ID
     hid_t faplid   = -1;
-    hid_t log_vlid = H5I_INVALID_HID;  // Logvol ID
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -40,10 +42,6 @@ int main (int argc, char **argv) {
         file_name = "group.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Creating groups")
-
     faplid = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (faplid)
     // MPI and collective metadata is required by LOG VOL
@@ -52,13 +50,22 @@ int main (int argc, char **argv) {
     err = H5Pset_all_coll_metadata_ops (faplid, 1);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Creating groups")
 
     // Create file
     fid = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -102,7 +109,6 @@ err_out:
     if (gid >= 0) H5Gclose (gid);
     if (fid >= 0) H5Fclose (fid);
     if (faplid >= 0) H5Pclose (faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/h5p_get_driver.cpp
+++ b/tests/basic/h5p_get_driver.cpp
@@ -13,8 +13,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define N 10
 
@@ -26,8 +30,6 @@ int main(int argc, char **argv) {
     hid_t faplid = -1;       // File Access Property List
     hid_t plist_id = -1;
     hid_t faplid2 = -1;
-    hid_t log_vlid = H5I_INVALID_HID;  // Logvol ID
-    vol_env env;
 
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
     MPI_Comm_size (MPI_COMM_WORLD, &np);
@@ -43,22 +45,27 @@ int main(int argc, char **argv) {
         file_name = "h5p_get_driver.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("Test H5Pget_driver")
-
     faplid = H5Pcreate(H5P_FILE_ACCESS);
     CHECK_ERR(faplid);
     err = H5Pset_fapl_mpio(faplid, MPI_COMM_WORLD, MPI_INFO_NULL);
     CHECK_ERR(err);
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
-        CHECK_ERR(log_vlid)
+        CHECK_ERR (log_vlid)
         err = H5Pset_vol (faplid, log_vlid, NULL);
-        CHECK_ERR(err)
+        CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("Test H5Pget_driver")
 
     // create file
     fid = H5Fcreate(file_name, H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -74,7 +81,6 @@ int main(int argc, char **argv) {
 err_out:
     if (fid >= 0) H5Fclose(fid);
     if (faplid >= 0) H5Pclose(faplid);
-    if (log_vlid != H5I_INVALID_HID) H5VLclose (log_vlid);
 
     SHOW_TEST_RESULT
 

--- a/tests/basic/makefile.alone
+++ b/tests/basic/makefile.alone
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2023, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+# Example:
+# 	 make -f makefile.alone MPICXX=$HOME/MPICH/4.1.2/bin/mpicxx \
+# 	                        MPIEXEC=$HOME/MPICH/4.1.2/bin/mpiexec \
+# 	                        HDF5_DIR=$HOME/HDF5/1.14.2
+
+SUFFIXES = .o .cpp
+
+CXX         = $(MPICXX)
+DFLAGS      =
+OPTFLAGS    = -g -O0 -Wall
+INCFLAGS    = -I$(HDF5_DIR)/include
+CXXFLAGS    = $(OPTFLAGS) $(DFLAGS) $(INCFLAGS)
+LDFLAGS     = -L$(HDF5_DIR)/lib
+LDLIBS      = -lhdf5
+
+check_PROGRAMS = attr \
+                 dread \
+                 dset \
+                 dwrite \
+                 file \
+                 fill \
+                 group \
+                 memsel \
+                 multiblockselection \
+                 multipointselection
+
+all: $(check_PROGRAMS) cache.cfg
+
+cache.cfg: ../../cache.cfg.in
+	cp -f $< $@
+
+ptest:
+	@echo "==========================================================="
+	@echo "    Parallel testing on 4 MPI processes"
+	@echo "==========================================================="
+	@for f in $(check_PROGRAMS) ; do \
+	     $(MPIEXEC) -n 4 ./$$f || exit 1 ; \
+	done
+
+clean:
+	rm -f core.* *.o *.h5 $(check_PROGRAMS) cache.cfg
+
+.PHONY: clean
+

--- a/tests/basic/multiblockselection.cpp
+++ b/tests/basic/multiblockselection.cpp
@@ -8,8 +8,12 @@
 #include <mpi.h>
 #include <hdf5.h>
 
+#ifdef TEST_H5VL_LOG
 #include "H5VL_log.h"
 #include "testutils.hpp"
+#else
+#include "common.hpp"
+#endif
 
 #define N 3
 #define M 3
@@ -18,10 +22,9 @@ int main (int argc, char **argv) {
     const char *file_name;
     int i, rank, np, nerrs=0, buf[M * M * N];
     herr_t err;
-    hid_t fcpl_id=-1, log_vlid=H5I_INVALID_HID;
+    hid_t fcpl_id=-1;
     hid_t file_id=-1, dspace_id=-1, dset_id=-1, mspace_id=-1, dxpl_id=-1;
     hsize_t dims[3], start[2], count[2];
-    vol_env env;
 
     int mpi_required;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_required);
@@ -39,10 +42,6 @@ int main (int argc, char **argv) {
         file_name = "multiblockselection.h5";
     }
 
-    /* check VOL related environment variables */
-    check_env(&env);
-    SHOW_TEST_INFO ("H5Sselect_hyperslab")
-
     // Set MPI-IO and parallel access proterty.
     fcpl_id = H5Pcreate (H5P_FILE_ACCESS);
     CHECK_ERR (fcpl_id)
@@ -59,13 +58,22 @@ int main (int argc, char **argv) {
     err = H5Pset_dxpl_mpio (dxpl_id, H5FD_MPIO_COLLECTIVE);
     CHECK_ERR (err)
 
+#ifdef TEST_H5VL_LOG
+    /* check VOL related environment variables */
+    vol_env env;
+    check_env(&env);
     if (env.native_only == 0 && env.connector == 0) {
+        hid_t log_vlid=H5I_INVALID_HID;
         // Register LOG VOL plugin
         log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
         CHECK_ERR (log_vlid)
         err = H5Pset_vol (fcpl_id, log_vlid, NULL);
         CHECK_ERR (err)
+        err = H5VLclose (log_vlid);
+        CHECK_ERR (err)
     }
+#endif
+    SHOW_TEST_INFO ("H5Sselect_hyperslab")
 
     // Create file
     file_id = H5Fcreate (file_name, H5F_ACC_TRUNC, H5P_DEFAULT, fcpl_id);
@@ -142,10 +150,6 @@ err_out:
     }
     if (mspace_id != -1) {
         err = H5Fclose (file_id);
-        CHECK_ERR (err)
-    }
-    if (log_vlid != H5I_INVALID_HID) {
-        err = H5VLclose (log_vlid);
         CHECK_ERR (err)
     }
     if (mspace_id != -1) {


### PR DESCRIPTION
In order to check whether an error was caused by Log VOL or other VOLs, this PR allows one to run test programs in tests/basic without Log VOL.  For instance, run command below to build all executables, with configuring Log VOL first.
```
export HDF5_DIR=${HOME}/HDF5
export LD_LIBRARY_PATH=${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
make -f makefile.alone MPICXX=${HOME}/MPICH/bin/mpicxx
```
Once the executable were built, one can test any VOL or any combination of VOLs by setting the VOL specific environment variables. For example, to run all test programs with Cache and Async VOLs enabled, use commands below.
```
export ABT_DIR=${HOME}/Argobots
export ASYNC_DIR=${HOME}/Async
export CACHE_DIR=${HOME}/Cache
export HDF5_DIR=${HOME}/HDF5
export HDF5_ROOT=${HDF5_DIR}
export HDF5_PLUGIN_PATH=${CACHE_DIR}/lib:${ASYNC_DIR}/lib
export LD_LIBRARY_PATH=${CACHE_DIR}/lib:${ASYNC_DIR}/lib:${ABT_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
export HDF5_VOL_CONNECTOR="cache_ext config=./cache.cfg;under_vol=512;under_info={under_vol=0;under_info={}}"
export MPICH_MAX_THREAD_SAFETY=multiple
export HDF5_USE_FILE_LOCKING=FALSE
export HDF5_ASYNC_DISABLE_DSET_GET=0
make -f makefile.alone MPIEXEC=${HOME}/MPICH/bin/mpiexec ptest
```